### PR TITLE
Added prefix to glitched shader

### DIFF
--- a/includes/colors.lua
+++ b/includes/colors.lua
@@ -180,7 +180,6 @@ local function replaceReplacedChars(str)
 end
 
 G.FUNCS.apply_colors = function()
-	sendDebugMessage('applying colors')
 	for i=1, 4 do
 		if G["CUSTOMHEX"..i] then
 			local hex = replaceReplacedChars(G["CUSTOMHEX"..i])

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -17,7 +17,7 @@ function load_cardsauce_item(file_key, item_type, no_badges)
 	local info = assert(SMODS.load_file("items/" .. key .. "/" .. file_key .. ".lua"))()
 
 	info.key = file_key
-	if item_type ~= 'Challenge' then
+	if item_type ~= 'Challenge' and item_type ~= 'Edition' then
 		info.atlas = file_key
 		info.pos = { x = 0, y = 0 }
 		if info.hasSoul then

--- a/items/editions/corrupted.lua
+++ b/items/editions/corrupted.lua
@@ -23,13 +23,13 @@ SMODS.Shader {
 }
 
 local editionInfo = {
-    shader = "glitched",
+    shader = "csau_glitched",
     config = {
         min = 2,
         max = 25,
     },
-    discovered = false,
     unlocked = true,
+    discovered = true,
     in_shop = true,
     weight = 14,
     extra_cost = 4,


### PR DESCRIPTION
- Added prefix to glitched shader key in Corrupted Edition
  - Why didn't it need this before? Hm
  - Using DebugPlus to discover cards in the collection still crashes, and I don't think it's my fault