### PR TITLE
Sprite Change Bugfixes

### DIFF
--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -423,7 +423,11 @@ G.FUNCS.csau_transform_card = function(card, to_key, evolve)
 	evolve = evolve or false
 	local old_card = card
 	local new_card = G.P_CENTERS[to_key]
-	card.children.center = Sprite(card.T.x, card.T.y, card.T.w, card.T.h, G.ASSET_ATLAS[new_card.atlas], new_card.pos)
+	card.children.center = Sprite(card.T.x, card.T.y, G.CARD_W, G.CARD_H, G.ASSET_ATLAS[new_card.atlas], new_card.pos)
+	card.children.center.scale = {
+		x = 71,
+		y = 95
+	}
 	card.children.center.states.hover = card.states.hover
 	card.children.center.states.click = card.states.click
 	card.children.center.states.drag = card.states.drag

--- a/items/blinds/outlaw.lua
+++ b/items/blinds/outlaw.lua
@@ -58,7 +58,11 @@ function blindInfo.get_loc_debuff_text(self)
 end
 
 function blindInfo.recalc_debuff(self, card, from_blind)
-    if card.area == G.jokers or G.GAME.blind.disabled or SMODS.has_no_rank(card) then
+    if not G.GAME.blind.played_ranks then
+        G.GAME.blind.played_ranks = {}
+    end
+
+    if card.area == G.jokers or G.GAME.blind.disabled or SMODS.has_no_rank(card) or not card.base.value then
         return false
     end
 

--- a/items/jokers/agga.lua
+++ b/items/jokers/agga.lua
@@ -21,19 +21,30 @@ function jokerInfo.loc_vars(self, info_queue, card)
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.repetition and not (context.end_of_round or context.blueprint) then
-        if card.ability.extra.x_mult > 1 and pseudorandom('agga') < G.GAME.probabilities.normal / card.ability.extra.prob then
-            if card.ability.extra.x_mult >= 3 then
-                check_for_unlock({ type = "high_agga" })
+    if context.individual and context.cardarea == G.play and not context.blueprint then
+        context.other_card.agga_retrigger_count = (context.other_card.agga_retrigger_count and context.other_card.agga_retrigger_count + 1) or 0
+
+        if context.other_card.agga_retrigger_count > 0 then
+            if card.ability.extra.x_mult > 1 and pseudorandom('agga') < G.GAME.probabilities.normal / card.ability.extra.prob then
+                if card.ability.extra.x_mult >= 3 then
+                    check_for_unlock({ type = "high_agga" })
+                end
+                card.ability.extra.x_mult = to_big(1)
+                card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_reset'), colour = G.C.IMPORTANT})
+            else
+                card.ability.extra.x_mult = to_big(card.ability.extra.x_mult) + to_big(card.ability.extra.x_mult_mod)
+                card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_xmult', vars = {to_big(card.ability.extra.x_mult)}}, colour = G.C.IMPORTANT})
             end
-            card.ability.extra.x_mult = to_big(1)
-            card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_reset'), colour = G.C.IMPORTANT})
-        else
-            card.ability.extra.x_mult = to_big(card.ability.extra.x_mult) + to_big(card.ability.extra.x_mult_mod)
-            card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_xmult', vars = {to_big(card.ability.extra.x_mult)}}, colour = G.C.IMPORTANT})
         end
     end
-    if context.joker_main and context.cardarea == G.jokers then
+
+    if context.after then
+        for _, v in ipairs(G.playing_cards) do
+            v.agga_retrigger_count = nil
+        end
+    end
+
+    if context.joker_main and context.cardarea == G.jokers and card.ability.extra.x_mult > 1 then
         return {
             message = localize{type='variable',key='a_xmult',vars={to_big(card.ability.extra.x_mult)}},
             Xmult_mod = card.ability.extra.x_mult,

--- a/items/jokers/bootleg.lua
+++ b/items/jokers/bootleg.lua
@@ -364,7 +364,8 @@ end
 
 local function get_loc_vars(self, card, info_queue)
     if card.ability.bootlegged_center.loc_vars then
-        return card.ability.bootlegged_center.loc_vars(card.ability.bootlegged_center, info_queue, card).vars or {}, nil, nil
+        local ret = card.ability.bootlegged_center.loc_vars(card.ability.bootlegged_center, info_queue, card)
+        return ret and ret.vars or {}, nil, nil
     elseif card.ability.bootlegged_center then
         local loc_vars, main_start, main_end = nil, nil, nil
         loc_vars, main_start, main_end = fuck_you_generate_ui_box_ability_table(card)

--- a/items/jokers/mug.lua
+++ b/items/jokers/mug.lua
@@ -19,36 +19,39 @@ local jokerInfo = {
 }
 
 local forms = {
-    ["Mug"] = {'mug', {x=0,y=0} },
-    ["Moment"] = {'moment', {x=1,y=0} },
+    ["Mug"] = {'mug', {x=0,y=0}, {w=71,h=73} },
+    ["Moment"] = {'moment', {x=1,y=0}, {w=71,h=95} },
 }
 
 local change_form = function(card, form)
     if forms[form] then
         card.ability.form = forms[form][1]
         card.config.center.pos = forms[form][2]
+        card.config.center.pixel_size = forms[form][3]
     else
         for k, v in pairs(forms) do
             if v[1] == form then
                 card.ability.form = v[1]
                 card.config.center.pos = v[2]
-                card.children.center.scale.y = card.children.center.scale.y*(95/95)
+                card.config.center.pixel_size = v[3]
             end
         end
     end
+
+    card.T.w = G.CARD_W
+    card.T.h = G.CARD_H
+    card:set_sprites(card.config.center)
+    card.config.center.pos = forms.Mug[2]
+    card.config.center.pixel_size = forms.Mug[3]
+    
     return card.ability.form
 end
 
 function jokerInfo.loc_vars(self, info_queue, card)
-    return { vars = { card.ability.extra.mult, card.ability.extra.rounds, card.ability.extra.x_mult } }
-end
-
-function jokerInfo.generate_ui(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
-    if card.area and card.area == G.jokers or card.config.center.discovered then
-        -- If statement makes it so that this function doesnt activate in the "Joker Unlocked" UI and cause 'Not Discovered' to be stuck in the corner
-        full_UI_table.name = localize{type = 'name', key = "j_csau_mug_"..card.ability.form, set = self.set, name_nodes = {}, vars = specific_vars or {}}
-    end
-    localize{type = 'descriptions', key = "j_csau_mug_"..card.ability.form, set = self.set, nodes = desc_nodes, vars = self.loc_vars(self, info_queue, card).vars}
+    return { 
+        vars = { card.ability.extra.mult, card.ability.extra.rounds, card.ability.extra.x_mult },
+        key = "j_csau_mug_"..card.ability.form
+    }
 end
 
 function jokerInfo.set_sprites(self, card, _front)
@@ -100,7 +103,6 @@ function jokerInfo.calculate(self, card, context)
                 check_for_unlock({ type = "activate_mug" })
                 change_form(card, "Moment")
                 card:juice_up(1, 1)
-                card:set_sprites(card.config.center)
                 return {
                     message = localize('k_mug_moment'),
                     colour = G.C.MUG
@@ -118,7 +120,6 @@ end
 function jokerInfo.update(self, card)
     if G.screenwipe then
         change_form(card, card.ability.form)
-        card:set_sprites(card.config.center)
     end
 end
 

--- a/items/jokers/odio.lua
+++ b/items/jokers/odio.lua
@@ -41,8 +41,10 @@ end
 local function updateSprite(card)
 	if card.ability.extra.form then
 		if card.config.center.atlas ~= card.ability.extra.form then
+			local old_atlas = card.config.center.atlas
 			card.config.center.atlas = "csau_"..card.ability.extra.form
 			card:set_sprites(card.config.center)
+			card.config.center.atlas = old_atlas
 		end
 	end
 end

--- a/items/jokers/sohappy.lua
+++ b/items/jokers/sohappy.lua
@@ -84,16 +84,20 @@ function jokerInfo.update(self, card)
 			G.localization.descriptions["Joker"]["j_csau_sohappy"] = G.localization.descriptions["Joker"]["j_csau_sohappy2"]
 		end
 		if card.config.center.atlas ~= "csau_sohappy" then
+			local old_atlas = card.config.center.atlas
 			card.config.center.atlas = "csau_sohappy"
 			card:set_sprites(card.config.center)
+			card.config.center.atlas = old_atlas
 		end
 	elseif card.ability.extra.side == 'sad' then
 		if G.localization.descriptions["Joker"]["j_csau_sohappy"] ~= G.localization.descriptions["Joker"]["j_csau_sosad"] then
 			G.localization.descriptions["Joker"]["j_csau_sohappy"] = G.localization.descriptions["Joker"]["j_csau_sosad"]
 		end
 		if card.config.center.atlas ~= "csau_sosad" then
+			local old_atlas = card.config.center.atlas
 			card.config.center.atlas = "csau_sosad"
 			card:set_sprites(card.config.center)
+			card.config.center.atlas = old_atlas
 		end
 	end
 end

--- a/items/jokers/sts.lua
+++ b/items/jokers/sts.lua
@@ -122,9 +122,22 @@ function jokerInfo.calculate(self, card, context)
                 if first.ability.effect == 'Wild Card' then
                     local form = change_form(card, "Wild Card")
                     card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_sts_'..card.ability.form), colour = form_color(form), update_sprites = true, juice_num1 = 0.7, juice_num2 = 0.7})
+                    
+                    -- resetting collection sprites
+                    G.E_MANAGER:add_event(Event({trigger = 'after', func = function()
+                        card.config.center.pos = forms.Base[2]
+                        return true end
+                    }))
+                    
                 else
                     local form = change_form(card, first.base.suit)
                     card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_sts_'..card.ability.form), colour = form_color(form), update_sprites = true, juice_num1 = 0.7, juice_num2 = 0.7})
+                    
+                    -- resetting collection sprites
+                    G.E_MANAGER:add_event(Event({trigger = 'after', func = function()
+                        card.config.center.pos = forms.Base[2]
+                        return true end
+                    }))
                 end
                 if card.ability.form == "spades" then
                     ease_discard(-G.GAME.current_round.discards_left, nil, true)
@@ -218,6 +231,7 @@ function jokerInfo.calculate(self, card, context)
             change_form(card, "Base")
             card:juice_up(1, 1)
             card:set_sprites(card.config.center)
+            card.config.center.pos = forms.Base[2]
         end
         if card.ability.diamonds.mult > 0 then
             card.ability.diamonds.mult = 0
@@ -238,6 +252,7 @@ function jokerInfo.update(self, card)
     if G.screenwipe then
         change_form(card, card.ability.form)
         card:set_sprites(card.config.center)
+        card.config.center.pos = forms.Base[2]
     end
 end
 

--- a/items/stands/steel_tusk_2.lua
+++ b/items/stands/steel_tusk_2.lua
@@ -53,7 +53,7 @@ function consumInfo.calculate(self, card, context)
         end
         card.ability.extra.evolve_destroys = card.ability.extra.evolve_destroys + cards
         if card.ability.extra.evolve_destroys >= card.ability.extra.evolve_num then
-            G.FUNCS.evolve_stand(card)
+            G.FUNCS.csau_evolve_stand(card)
             return
         else
             return {

--- a/items/stands/steel_tusk_3.lua
+++ b/items/stands/steel_tusk_3.lua
@@ -48,7 +48,7 @@ function consumInfo.calculate(self, card, context)
     if context.end_of_round and not card.debuff and not context.individual and not context.repetition and not context.blueprint then
         if G.GAME.chips <= (G.GAME.blind.chips * (1+card.ability.extra.evolve_percent)) then
             check_for_unlock({ type = "evolve_tusk" })
-            G.FUNCS.evolve_stand(card)
+            G.FUNCS.csau_evolve_stand(card)
         end
     end
 end

--- a/items/vhs/blackspine.lua
+++ b/items/vhs/blackspine.lua
@@ -21,7 +21,7 @@ function consumInfo.loc_vars(self, info_queue, card)
 end
 
 function consumInfo.activate(self, card, on)
-    local key = pseudorandom_element(get_current_pool('VHS', nil, nil, 'blackspine'), pseudoseed('blackspine'))
+    local key = pseudorandom_element(get_current_pool('csau_VHS', nil, nil, 'blackspine'), pseudoseed('blackspine'))
     G.FUNCS.csau_transform_card(card, key)
 end
 


### PR DESCRIPTION
- Fixed Odious Joker, Murder the Monolith, I'm So Happy, and Mug to always show default forms in the collection
- Fixed Mug Moment scale upon transformation
- Fixed a bug with deck preview erroring on an invisible card against The Outlaw
- Fixed AGGA to only trigger on retriggers
- Fixed Bootleg Joker accessing `vars` on jokers that return nil from their `loc_vars()` function
- Added a check for scale and dimensions in `G.FUNCS.csau_transform_card()` to correctly account for cards like Half Joker, Square Joker, etc
- Fixed some incorrect references to `G.FUNCS.csau_evolve_stand()`