### PR TITLE
Fixed a bunch of VHS visual bugs

### DIFF
--- a/includes/hooks/card.lua
+++ b/includes/hooks/card.lua
@@ -237,6 +237,10 @@ function Card:set_ability(center, initial, delay_sprites)
         G.FUNCS.csau_set_stand_sprites(self)
     end
 
+    if self.ability.set == 'VHS' then
+        self.no_shadow = true
+    end
+
     return ret
 end
 
@@ -246,6 +250,10 @@ function Card:load(cardTable, other_card)
 
     if self.ability.set == 'csau_Stand' then
         G.FUNCS.csau_set_stand_sprites(self)
+    end
+    
+    if self.ability.set == 'VHS' then
+        self.no_shadow = true
     end
 
     return ret

--- a/includes/shaders.lua
+++ b/includes/shaders.lua
@@ -316,13 +316,24 @@ local width_factor = 0.1
 local old_center_ds = SMODS.DrawSteps.center.func
 SMODS.DrawStep:take_ownership('center', {
     func = function(self, layer)
-        if self.ability.set == 'VHS' then
+        if self.ability.set ~= 'VHS' then
+            old_center_ds(self, layer)
+        end
+    end
+})
+
+SMODS.DrawStep {
+    key = 'vhs_slide',
+    order = -1,
+    func = function(self, layer)
+        if self.ability.set ~= 'VHS' or (self.area and self.area.config.collection and not self.config.center.discovered) then
             --If the card is not yet discovered
-            if not self.config.center.discovered and (self.ability.consumeable or self.config.center.unlocked) and not self.config.center.demo and not self.bypass_discovery_center then
-                local shared_sprite = (self.ability.set == 'Edition' or self.ability.set == 'Joker') and G.shared_undiscovered_joker or G.shared_undiscovered_tarot
+            if not self.config.center.discovered then
+                local shared_sprite = G.shared_undiscovered_tarot
                 local scale_mod = -0.05 + 0.05*math.sin(1.8*G.TIMERS.REAL)
                 local rotate_mod = 0.03*math.sin(1.219*G.TIMERS.REAL)
 
+                self.children.center:draw_shader('dissolve')
                 shared_sprite.role.draw_major = self
                 if (self.config.center.undiscovered and not self.config.center.undiscovered.no_overlay) or not( SMODS.UndiscoveredSprites[self.ability.set] and SMODS.UndiscoveredSprites[self.ability.set].no_overlay) then 
                     shared_sprite:draw_shader('dissolve', nil, nil, nil, self.children.center, scale_mod, rotate_mod)
@@ -332,23 +343,7 @@ SMODS.DrawStep:take_ownership('center', {
                     end
                 end
             end
-
-            local center = self.config.center
-            if center.draw and type(center.draw) == 'function' then
-                center:draw(self, layer)
-            end
-            return
-        end
-
-        return old_center_ds(self, layer)
-    end
-})
-
-SMODS.DrawStep {
-    key = 'vhs_slide',
-    order = -1,
-    func = function(self)
-        if self.ability.set ~= 'VHS' or (self.area and self.area.config.collection and not self.config.center.discovered) then
+            
             return
         end
 
@@ -395,6 +390,11 @@ SMODS.DrawStep {
 
         self.children.center:draw_shader('csau_vhs', self.shadow_height)
 	    self.children.center:draw_shader('csau_vhs', nil)
+
+        local center = self.config.center
+        if center.draw and type(center.draw) == 'function' then
+            center:draw(self, layer)
+        end
     end,
     conditions = { vortex = false, facing = 'front' },
 }

--- a/includes/shaders.lua
+++ b/includes/shaders.lua
@@ -313,6 +313,37 @@ local slide_mod = 12
 local slide_out_delay = 0.05
 local width_factor = 0.1
 
+local old_center_ds = SMODS.DrawSteps.center.func
+SMODS.DrawStep:take_ownership('center', {
+    func = function(self, layer)
+        if self.ability.set == 'VHS' then
+            --If the card is not yet discovered
+            if not self.config.center.discovered and (self.ability.consumeable or self.config.center.unlocked) and not self.config.center.demo and not self.bypass_discovery_center then
+                local shared_sprite = (self.ability.set == 'Edition' or self.ability.set == 'Joker') and G.shared_undiscovered_joker or G.shared_undiscovered_tarot
+                local scale_mod = -0.05 + 0.05*math.sin(1.8*G.TIMERS.REAL)
+                local rotate_mod = 0.03*math.sin(1.219*G.TIMERS.REAL)
+
+                shared_sprite.role.draw_major = self
+                if (self.config.center.undiscovered and not self.config.center.undiscovered.no_overlay) or not( SMODS.UndiscoveredSprites[self.ability.set] and SMODS.UndiscoveredSprites[self.ability.set].no_overlay) then 
+                    shared_sprite:draw_shader('dissolve', nil, nil, nil, self.children.center, scale_mod, rotate_mod)
+                else
+                    if SMODS.UndiscoveredSprites[self.ability.set] and SMODS.UndiscoveredSprites[self.ability.set].overlay_sprite then
+                        SMODS.UndiscoveredSprites[self.ability.set].overlay_sprite:draw_shader('dissolve', nil, nil, nil, self.children.center, scale_mod, rotate_mod)
+                    end
+                end
+            end
+
+            local center = self.config.center
+            if center.draw and type(center.draw) == 'function' then
+                center:draw(self, layer)
+            end
+            return
+        end
+
+        return old_center_ds(self, layer)
+    end
+})
+
 SMODS.DrawStep {
     key = 'vhs_slide',
     order = -1,
@@ -334,73 +365,36 @@ SMODS.DrawStep {
                 if self.ability.slide_move > 1 then
                     self.ability.slide_move = 1
                 end
-                self.children.center:set_role({
-                    role_type = 'Minor',
-                    offset = {x = -0.25 * self.ability.slide_move, y = 0},
-                    major = self,
-                    draw_major = self,
-                    xy_bond = 'Strong',
-                    wh_bond = 'Strong',
-                    r_bond = 'Strong',
-                    scale_bond = 'Strong'
-                })
             end
         elseif not self.ability.activated and self.ability.slide_move > 0 then
             self.ability.slide_out_delay = 0
             self.ability.slide_move = self.ability.slide_move - (slide_mod * G.real_dt)
+            
             if self.ability.slide_move < 0 then
                 self.ability.slide_move = 0
+                self.children.center.VT.w = self.T.w
             end
-            self.children.center:set_role({
-                role_type = 'Minor',
-                offset = {x = -0.25 * self.ability.slide_move, y = 0},
-                major = self,
-                draw_major = self,
-                xy_bond = 'Strong',
-                wh_bond = 'Strong',
-                r_bond = 'Strong',
-                scale_bond = 'Strong'
-            })
+            
         end
 
         if self.ability.slide_move <= 0 then
-            self.children.center.VT.w = self.T.w
+            self.children.center:draw_shader('dissolve', self.shadow_height)
+	        self.children.center:draw_shader('dissolve')
             return
         end
 
         -- adjusting the width to match the shader change
-        self.children.center.VT.w = (self.T.w * width_factor * self.ability.slide_move) + self.T.w
-
-        -- default tilt behavior
-        local cursor_pos = {}
-        cursor_pos[1] = self.tilt_var and self.tilt_var.mx*G.CANV_SCALE or G.CONTROLLER.cursor_position.x*G.CANV_SCALE
-        cursor_pos[2] = self.tilt_var and self.tilt_var.my*G.CANV_SCALE or G.CONTROLLER.cursor_position.y*G.CANV_SCALE
-        local _draw_major = self.role.draw_major or self
-        local screen_scale = G.TILESCALE*G.TILESIZE*(self.children.center.mouse_damping or 1)*G.CANV_SCALE
-        local hovering = (self.hover_tilt or 0)
-
-        for i=1, 2 do
-            local shadow_height = self.shadow_height
-            if i==2 then
-                shadow_height = nil
-            end
-
-            G.SHADERS['csau_vhs']:send('spine', G.ASSET_ATLAS['csau_blackspine'].image)
-            G.SHADERS['csau_vhs']:send('lerp', self.ability.slide_move)
-            G.SHADERS['csau_vhs']:send('mouse_screen_pos', cursor_pos)
-            G.SHADERS['csau_vhs']:send('screen_scale', screen_scale)
-            G.SHADERS['csau_vhs']:send('hovering', hovering)
-            G.SHADERS['csau_vhs']:send("texture_details",self.children.center:get_pos_pixel())
-            G.SHADERS['csau_vhs']:send("image_details",self.children.center:get_image_dims())
-            G.SHADERS['csau_vhs']:send("dissolve",math.abs(_draw_major.dissolve or 0))
-            G.SHADERS['csau_vhs']:send("burn_colour_1",_draw_major.dissolve_colours and _draw_major.dissolve_colours[1] or G.C.CLEAR)
-            G.SHADERS['csau_vhs']:send("burn_colour_2",_draw_major.dissolve_colours and _draw_major.dissolve_colours[2] or G.C.CLEAR)
-            G.SHADERS['csau_vhs']:send("shadow",(not not shadow_height))
-            love.graphics.setShader(G.SHADERS['csau_vhs'], G.SHADERS['csau_vhs'])
-            self.children.center:draw_self()
-            love.graphics.setShader()
+        if not self.children.center.pinch.x then
+            self.children.center.VT.x = self.T.x - width_factor * self.ability.slide_move * 2
+            self.children.center.VT.w = (self.T.w * width_factor * self.ability.slide_move) + self.T.w
         end
 
+        -- default tilt behavior
+        G.SHADERS['csau_vhs']:send('spine', G.ASSET_ATLAS['csau_blackspine'].image)
+        G.SHADERS['csau_vhs']:send('lerp', self.ability.slide_move)
+
+        self.children.center:draw_shader('csau_vhs', self.shadow_height)
+	    self.children.center:draw_shader('csau_vhs', nil)
     end,
     conditions = { vortex = false, facing = 'front' },
 }

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -187,6 +187,7 @@ function load_cardsauce_item(file_key, item_type)
 			atd_ref(self, card)
 			set_consumeable_usage(card)
 		end
+
 		if item_type == 'Stand' and info.rarity == 'csau_EvolvedRarity' then
 			local sctb_ref = function(self, card, badges) end
 			if info.set_card_type_badge then
@@ -587,37 +588,45 @@ end
 
 --- Destroys a VHS tape and calls all relevant contexts
 --- @param card Card Balatro Card object of VHS tape to destroy
---- @param delay number Event delay in seconds
+--- @param delay_time number Event delay in seconds
 --- @param ach string | nil Achievement type key, will check for achievement unlock if not nil
 --- @param silent boolean | nil Plays tarot sound effect on destruction if true
-G.FUNCS.destroy_tape = function(card, delay, ach, silent)
-    G.E_MANAGER:add_event(Event({
+G.FUNCS.destroy_tape = function(card, delay_time, ach, silent, text)
+	G.E_MANAGER:add_event(Event({
         trigger = 'after',
-        delay = delay,
+        delay = delay_time,
         func = function()
-            if not silent then
+			attention_text({
+				text = localize(text or 'k_vhs_destroyed'),
+				scale = 1,
+				hold = 0.5,
+				backdrop_colour = G.C.VHS,
+				align = 'bm',
+				major = card,
+				offset = {x = 0, y = 0.05*card.T.h}
+			})
+			play_sound('generic1')
+
+			delay(0.15)
+
+			if not silent then
                 play_sound('tarot1')
             end
-            card.T.r = -0.2
-            card:juice_up(0.3, 0.4)
+            card.T.r = -0.1
+			card:juice_up(0.3, 0.4)
             card.states.drag.is = true
             card.children.center.pinch.x = true
+			
             G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
                  func = function()
-					 if card.config.center.activate and type(card.config.center.activate) == 'function' then
-						 card.config.center.activate(card.config.center, card, false)
-					 end
-                     card:start_dissolve({ G.C.VHS, G.C.RED })
-                     --G.consumeables:remove_card(card)
-                     --card:remove()
-                     --card = nil
-                     return true
-                 end
-            }))
-            G.E_MANAGER:add_event(Event({trigger = 'after',
-                 func = function()
-                     SMODS.calculate_context({vhs_death = true, card = card})
-                     return true
+					if card.config.center.activate and type(card.config.center.activate) == 'function' then
+						card.config.center.activate(card.config.center, card, false)
+					end
+
+					SMODS.calculate_context({vhs_death = true, card = card})
+
+                    card:remove()
+                    return true
                  end
             }))
             if ach then

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -338,6 +338,7 @@ return {
 			k_galaxy = "Galaxy",
 			k_galaxy_q = "Galaxy?",
 			k_vhs = "VHS Tape",
+			k_vhs_destroyed = "Fin!",
 			k_csau_stand = "Stand",
 			b_csau_stand_cards = "Stands",
 			k_csau_evolved = "Evolved Stand",


### PR DESCRIPTION
- Fixed VHS tapes drawing shadows twice for the main center
- Removed VHS tapes from default center drawing
- Fixed a bug where destroyed tapes tweened towards the bottom center due to using roles to set their position
- Added attention text to VHS destruction
- Moved VHS destroyed calculate context a little earlier because it no longer uses start_dissolve()