### PR TITLE
Corrupted now has a Misprint-esque display

### DIFF
--- a/items/blinds/hog.lua
+++ b/items/blinds/hog.lua
@@ -31,19 +31,15 @@ function blindInfo.recalc_debuff(self, card, from_blind)
 
     if card.csau_hogstruck then
         if card:is_face(true) then
-            sendDebugMessage('still face card, stay hogged')
             return true
         end
 
-        sendDebugMessage('unhoggd')
         card.csau_hogstruck = nil
         card.csau_hog_checked = nil
         return false
     elseif card:is_face(true) and not card.csau_hog_checked then
         card.csau_hog_checked = true
-        sendDebugMessage('retested for hog')
         if pseudorandom(pseudoseed('csau_hog')) < G.GAME.probabilities.normal/2 then
-            sendDebugMessage('newly hoggd')
             card.csau_hogstruck = true
             return true
         end

--- a/items/consumables/banned_consumables.lua
+++ b/items/consumables/banned_consumables.lua
@@ -1,7 +1,8 @@
 local consumInfo = {
     name = "Banned Consumables",
+    set = "Tarot",
+    config = {},
     no_doe = true,
-    omit = true,
     no_mod_badges = true,
     no_collection = true,
     width = 169,

--- a/items/jokers/banned_cards.lua
+++ b/items/jokers/banned_cards.lua
@@ -4,7 +4,6 @@ local jokerInfo = {
     rarity = 1,
     cost = 1,
     no_doe = true,
-    omit = true,
     no_mod_badges = true,
     no_collection = true,
     discovered = true,

--- a/items/jokers/banned_jokers.lua
+++ b/items/jokers/banned_jokers.lua
@@ -6,7 +6,6 @@ local jokerInfo = {
     no_mod_badges = true,
     no_collection = true,
     no_doe = true,
-    omit = true,
     discovered = true,
     unlocked = true,
     blueprint_compat = false,

--- a/items/tags/banned_tags.lua
+++ b/items/tags/banned_tags.lua
@@ -1,7 +1,6 @@
 local tagInfo = {
     name = "Banned Tags",
     no_doe = true,
-    omit = true,
     no_mod_badges = true,
     no_collection = true,
     width = 169,

--- a/items/vouchers/banned_vouchers.lua
+++ b/items/vouchers/banned_vouchers.lua
@@ -3,7 +3,6 @@ local voucherInfo = {
     cost = 1,
     config = {},
     no_doe = true,
-    omit = true,
     no_mod_badges = true,
     no_collection = true,
     discovered = true,

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -3447,30 +3447,9 @@ return {
 			e_csau_corrupted = {
 				name = "Corrupted",
 				text = {
-					"{C:green}3 in 20{} chance for {X:mult,C:white}X1.5{} Mult,",
-					"{C:green}7 in 20{} chance for {C:mult}+10{} Mult,",
-					"or {C:green}10 in 20{} chance for {C:chips}+50{} Chips",
-					"{s:0.8,C:inactive}(Odds not affected by probability manipulation){}",
+					"",
 				},
 			},
-			e_csau_corrupted_x_mult = {
-				name = "Corrupted",
-				text = {
-					"{E:2,X:mult,C:white}X1.5{} Mult",
-				},
-			},
-			e_csau_corrupted_mult = {
-				name = "Corrupted",
-				text = {
-					"{E:2,C:mult}+10{} Mult",
-				},
-			},
-			e_csau_corrupted_chips = {
-				name = "Corrupted",
-				text = {
-					"{E:2,C:chips}+50{} Chips",
-				},
-			}
 		},
 		Back = {
 			b_csau_vine = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -3452,6 +3452,24 @@ return {
 					"or {C:green}10 in 20{} chance for {C:chips}+50{} Chips",
 					"{s:0.8,C:inactive}(Odds not affected by probability manipulation){}",
 				},
+			},
+			e_csau_corrupted_x_mult = {
+				name = "Corrupted",
+				text = {
+					"{E:2,X:mult,C:white}X1.5{} Mult",
+				},
+			},
+			e_csau_corrupted_mult = {
+				name = "Corrupted",
+				text = {
+					"{E:2,C:mult}+10{} Mult",
+				},
+			},
+			e_csau_corrupted_chips = {
+				name = "Corrupted",
+				text = {
+					"{E:2,C:chips}+50{} Chips",
+				},
 			}
 		},
 		Back = {

--- a/lovely/corrupted_display.toml
+++ b/lovely/corrupted_display.toml
@@ -1,0 +1,38 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 9999999
+
+[[patches]]
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = '''pop_in_rate = 4,'''
+position = "at"
+payload = '''pop_in_rate = args.no_recycle and 99999999 or 4,'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = '''=[SMODS _ "src/game_object.lua"]'''
+pattern = '''full_UI_table.name = self.set == 'Enhanced' and 'temp_value' or localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or target.vars or {} }'''
+position = "at"
+payload = '''full_UI_table.name = self.set == 'Enhanced' and 'temp_value' or localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or target.vars or {}, no_recycle = (card and card.edition and card.edition.no_recycle or nil) }'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = '''=[SMODS _ "src/game_object.lua"]'''
+pattern = '''desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = target.set }'''
+position = "at"
+payload = '''desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = target.set, no_recycle = (card and card.edition and card.edition.no_recycle or nil) }'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = '''functions/common_events.lua'''
+pattern = '''full_UI_table.name = localize{type = 'name', set = _c.set, key = _c.key, nodes = full_UI_table.name}'''
+position = "at"
+payload = '''full_UI_table.name = localize{type = 'name', set = _c.set, key = _c.key, nodes = full_UI_table.name, no_recycle = (card and card.edition and card.edition.no_recycle or nil) }'''
+match_indent = true
+
+

--- a/lovely/corrupted_display.toml
+++ b/lovely/corrupted_display.toml
@@ -5,34 +5,23 @@ priority = 9999999
 
 [[patches]]
 [patches.pattern]
-target = "functions/misc_functions.lua"
-pattern = '''pop_in_rate = 4,'''
-position = "at"
-payload = '''pop_in_rate = args.no_recycle and 99999999 or 4,'''
+target = "functions/common_events.lua"
+pattern = '''t.set = res.set or t.set'''
+position = "after"
+payload = '''t.main_start = res.main_start or t.main_start'''
 match_indent = true
+times = 1
 
 [[patches]]
 [patches.pattern]
-target = '''=[SMODS _ "src/game_object.lua"]'''
-pattern = '''full_UI_table.name = self.set == 'Enhanced' and 'temp_value' or localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or target.vars or {} }'''
+target = "functions/common_events.lua"
+pattern = '''if main_start then 
+    desc_nodes[#desc_nodes+1] = main_start 
+end'''
 position = "at"
-payload = '''full_UI_table.name = self.set == 'Enhanced' and 'temp_value' or localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or target.vars or {}, no_recycle = (card and card.edition and card.edition.no_recycle or nil) }'''
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = '''=[SMODS _ "src/game_object.lua"]'''
-pattern = '''desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = target.set }'''
-position = "at"
-payload = '''desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = target.set, no_recycle = (card and card.edition and card.edition.no_recycle or nil) }'''
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = '''functions/common_events.lua'''
-pattern = '''full_UI_table.name = localize{type = 'name', set = _c.set, key = _c.key, nodes = full_UI_table.name}'''
-position = "at"
-payload = '''full_UI_table.name = localize{type = 'name', set = _c.set, key = _c.key, nodes = full_UI_table.name, no_recycle = (card and card.edition and card.edition.no_recycle or nil) }'''
+payload = '''if _c.main_start or main_start then 
+    desc_nodes[#desc_nodes+1] = _c.main_start or main_start 
+end'''
 match_indent = true
 
 

--- a/lovely/jokers.toml
+++ b/lovely/jokers.toml
@@ -152,12 +152,3 @@ position = "at"
 payload = "play_sound(G.FUNCS.nutbuster_active() and 'csau_doot' or 'tarot2', G.FUNCS.nutbuster_active() and 1 or 0.76, 0.4);return true end}))"
 match_indent = true
 times = 1
-
-[[patches]]
-[patches.pattern]
-target = "functions/misc_functions.lua"
-pattern = "if v.set == 'Joker' then"
-position = "at"
-payload = "if v.set == 'Joker' and not v.omit then "
-match_indent = true
-times = 1


### PR DESCRIPTION
- Added descriptions for Corrupted edition that cycle between Foil, Holographic, and Polychrome effects using Dynatext
  - This required a lovely patch to add `main_end` support for editions
- Cleaned up Debug statements in The Hog blind
- Removed 'omit' from various banned dummy items (SMODS now checks for `no_collection` instead, update your SMODS)