### PR TITLE
Blind Compatibility Update

### DIFF
--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -950,7 +950,16 @@ SMODS.food_expires = function(context)
 end
 
 SMODS.return_to_hand = function(card, context)
-	if G.GAME.blind.boss and G.GAME.blind.name == "The Vod" then return true end
+	if not G.GAME.blind.disabled and G.GAME.blind.name == 'The Vod' then 
+        return true
+    else
+        for _, v in ipairs(G.GAME.fnwk_extra_blinds) do
+            if not v.disabled and v.name == 'The Vod' then
+                return true
+            end
+        end
+    end
+	
 	if G.FUNCS.find_activated_tape('c_csau_yoyoman') and table.contains(context.scoring_hand, card) then return true end
 	if context.scoring_name == "High Card" and next(SMODS.find_card("j_csau_besomeone")) and table.contains(context.scoring_hand, card) then return true end
 	return false

--- a/items/blinds/darkest.lua
+++ b/items/blinds/darkest.lua
@@ -15,10 +15,6 @@ function blindInfo.defeat(self)
     check_for_unlock({ type = "defeat_darkest" })
 end
 
-function blindInfo.set_blind(self)
-    G.GAME.blind.played_ranks = {}
-end
-
 function blindInfo.modify_hand(self, cards, poker_hands, text, mult, hand_chips)
     -- only use non face ranks
     -- this would support modded numbered ranks, thank you 161 of clubs

--- a/items/blinds/feltfortress.lua
+++ b/items/blinds/feltfortress.lua
@@ -16,47 +16,44 @@ function blindInfo.defeat(self)
     check_for_unlock({ type = "defeat_feltfortress" })
 end
 
-blindInfo.set_blind = function(self, reset, silent)
-    if not G.GAME.blind.disabled then
-        G.GAME.blind.backup_chips = G.GAME.blind.chips
-    end
-end
-
 blindInfo.press_play = function(self)
-    G.GAME.blind.activated = true
+    if not G.GAME.blind.disabled then
+        G.GAME.blind.activated = true
+        G.GAME.blind.fortress_num_hands = (G.GAME.blind.fortress_num_hands or 0) + 1
+    end
 end
 
 --Modified code from Math Blinds
 blindInfo.drawn_to_hand = function(self)
     if not G.GAME.blind.disabled and G.GAME.blind.activated then
         G.GAME.blind.activated = false
-        local new_chips = math.floor(G.GAME.blind.chips * 2)
+        G.GAME.blind.chips = math.floor(G.GAME.blind.chips * 2)
+        G.GAME.blind.chip_text = number_format(G.GAME.blind.chips)
         G.GAME.blind:wiggle()
         play_area_status_text(localize('k_fort_doubled'))
-        G.E_MANAGER:add_event(Event({
-            trigger = 'ease',
-            blocking = false,
-            ref_table = G.GAME.blind,
-            ref_value = 'chips',
-            ease_to = new_chips,
-            delay =  0.5,
-            func = (function(t) G.GAME.blind.chip_text = number_format(G.GAME.blind.chips); return math.floor(t) end)
-        }))
-        G.E_MANAGER:add_event(Event({
-            trigger = 'after',
-            delay = 0.5,
-            func = function()
-                G.GAME.blind.chip_text = number_format(G.GAME.blind.chips)
-                return true
-            end
-        }))
+        G.hand_text_area.blind_chips:juice_up()
     end
 end
 
 blindInfo.disable = function(self, silent)
-    G.GAME.blind.chips = G.GAME.blind.backup_chips
+    G.GAME.blind.chips = math.floor(G.GAME.blind.chips * (2 ^ (-1 * (G.GAME.blind.fortress_num_hands or 0))))
     G.GAME.blind.chip_text = number_format(G.GAME.blind.chips)
-    G.GAME.blind.backup_chips = nil
+    G.GAME.blind.fortress_num_hands = nil
+end
+
+--- this feels like it's going to get me killed
+local ref_blind_save = Blind.save
+function Blind:save()
+	local ret = ref_blind_save(self)
+    ret.fortress_num_hands = self.fortress_num_hands
+	return ret
+end
+
+local ref_blind_load = Blind.load
+function Blind:load(blindTable)
+	local ret = ref_blind_load(self, blindTable)
+    self.fortress_num_hands = blindTable.fortress_num_hands
+    return ret
 end
 
 return blindInfo

--- a/items/blinds/finger.lua
+++ b/items/blinds/finger.lua
@@ -14,9 +14,7 @@ function blindInfo.defeat(self)
 end
 
 function blindInfo.debuff_hand(self, cards, hand, handname, check)
-    if handname == "High Card" then
-        return true
-    end
+    return (not G.GAME.blind.disabled and handname == "High Card")
 end
 
 return blindInfo

--- a/items/blinds/hog.lua
+++ b/items/blinds/hog.lua
@@ -14,6 +14,8 @@ local blindInfo = {
 
 function blindInfo.set_blind(self)
     for _, v in ipairs(G.playing_cards) do
+        v.csau_hogstruck = nil
+        v.csau_hog_checked = nil
         if v:is_face(true) then
             if pseudorandom(pseudoseed('csau_hog')) < G.GAME.probabilities.normal/2 then
                 v.csau_hogstruck = true
@@ -61,6 +63,7 @@ function blindInfo.defeat(self)
     for _, v in ipairs(G.playing_cards) do
         v.csau_hogstruck = nil
         v.csau_hog_checked = nil
+        v:set_debuff(false)
     end
 end
 

--- a/items/blinds/hog.lua
+++ b/items/blinds/hog.lua
@@ -63,7 +63,6 @@ function blindInfo.defeat(self)
     for _, v in ipairs(G.playing_cards) do
         v.csau_hogstruck = nil
         v.csau_hog_checked = nil
-        v:set_debuff(false)
     end
 end
 

--- a/items/blinds/mochamike.lua
+++ b/items/blinds/mochamike.lua
@@ -9,38 +9,12 @@ local blindInfo = {
     boss = {min = 1, max = 10, showdown = true}
 }
 
-local function get_most_played(lock)
-    lock = lock or false
-    if G.GAME.blind.most_played then
-        return G.GAME.blind.most_played
-    else
-        local most_played = "High Card"
-        local play_more_than = (G.GAME.hands["High Card"].played or 0)
-        for k, v in pairs(G.GAME.hands) do
-            if to_big(v.played) >= to_big(play_more_than) and v.visible then
-                play_more_than = v.played
-                most_played = k
-            end
-        end
-        if lock then
-            G.GAME.blind.most_played = most_played
-        end
-        return most_played
-    end
-
-end
-
 function blindInfo.defeat(self)
     check_for_unlock({ type = "defeat_mochamike" })
 end
 
-function blindInfo.set_blind(self)
-    G.GAME.blind.most_played = get_most_played(true)
-end
-
 function blindInfo.loc_vars(self)
-    local most_played = get_most_played()
-    return {vars = { localize(most_played, 'poker_hands') or localize('ph_most_played') } }
+    return {vars = { localize(G.GAME.current_round.most_played_poker_hand, 'poker_hands') or localize('ph_most_played') } }
 end
 
 function blindInfo.collection_loc_vars(self)
@@ -48,10 +22,7 @@ function blindInfo.collection_loc_vars(self)
 end
 
 function blindInfo.debuff_hand(self, cards, hand, handname, check)
-    local most_played = get_most_played()
-    if handname == most_played then
-        return true
-    end
+    return (not G.GAME.blind.disabled and handname == G.GAME.current_round.most_played_poker_hand)
 end
 
 return blindInfo

--- a/items/blinds/outlaw.lua
+++ b/items/blinds/outlaw.lua
@@ -31,7 +31,7 @@ function blindInfo.drawn_to_hand(self)
 end
 
 function blindInfo.get_loc_debuff_text(self)
-    if not (next(G.GAME.blind.played_ranks)) then
+    if not G.GAME.blind.played_ranks or not (next(G.GAME.blind.played_ranks)) then
         return "Debuffs all ranks played last hand"
     end
 

--- a/items/blinds/paint.lua
+++ b/items/blinds/paint.lua
@@ -15,10 +15,6 @@ function blindInfo.defeat(self)
     check_for_unlock({ type = "defeat_paint" })
 end
 
-function blindInfo.set_blind(self)
-    G.GAME.blind.played_ranks = {}
-end
-
 function blindInfo.modify_hand(self, cards, poker_hands, text, mult, hand_chips)
     -- only use non face ranks
     -- this would support modded numbered ranks, thank you 161 of clubs

--- a/items/blinds/wasp.lua
+++ b/items/blinds/wasp.lua
@@ -16,10 +16,17 @@ function blindInfo.defeat(self)
     check_for_unlock({ type = "defeat_wasp" })
 end
 
-local function american_hornet(blind)
-    if blind.boss and blind.name == "The Wasp" and not G.GAME.blind.disabled then
+local function american_hornet()
+    if not G.GAME.blind.disabled and G.GAME.blind.name == 'The Wasp' then 
         return true
+    else
+        for _, v in ipairs(G.GAME.fnwk_extra_blinds) do
+            if not v.disabled and v.name == 'The Wasp' then
+                return true
+            end
+        end
     end
+
     return false
 end
 
@@ -28,14 +35,14 @@ local ref_eval = eval_card
 function eval_card(card, context)
     local ret = {}
     local post_trig = {}
-    if (context.repetition or context.retrigger_joker) and G.GAME and G.GAME.blind and american_hornet(G.GAME.blind) then return ret, post_trig end
+    if (context.repetition or context.retrigger_joker) and american_hornet() then return ret, post_trig end
     return ref_eval(card, context)
 end
 
 local ref_calc_retrig = SMODS.calculate_retriggers
 SMODS.calculate_retriggers = function(card, context, _ret)
     local retriggers = {}
-    if (context.repetition or context.retrigger_joker) and american_hornet(G.GAME.blind) then return retriggers end
+    if (context.repetition or context.retrigger_joker) and american_hornet() then return retriggers end
     return ref_calc_retrig(card, context, _ret)
 end
 

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -833,67 +833,67 @@ return {
 			bl_csau_hog = {
 				name="The Hog",
 				text={
-					"#1# in 2 face cards",
+					"{C:green}#1# in 2{} {C:attention}face{} cards",
 					"become The Hog's prey"
 				},
 			},
 			bl_csau_tray = {
 				name="The Tray",
 				text={
-					"#1# in #2# chance to divide",
-					"base Chips and Mult by 3"
+					"{C:green}#1# in #2#{} chance to divide",
+					"base Chips and Mult by {C:attention}3{}"
 				},
 			},
 			bl_csau_vod = {
 				name="The Vod",
 				text={
 					"Played cards",
-					"are redrawn"
+					"are {C:attention}redrawn{}"
 				},
 			},
 			bl_csau_outlaw = {
 				name = "The Outlaw",
 				text = {
-					"Debuffs all ranks",
-					"scored last hand"
+					"Debuffs all {C:attention}ranks{}",
+					"scored {C:attention}last hand{}"
 				},
 			},
 			bl_csau_darkest = {
 				name = "The Darkest",
 				text = {
-					"Scoring face cards become",
-					"a random numbered rank"
+					"Scoring {C:attention}face{} cards become",
+					"a random {C:attention}numbered rank{}"
 				},
 			},
 			bl_csau_finger = {
 				name="The Finger",
 				text={
-					"High Card will not score"
+					"{C:attention}High Card{} will not score"
 				},
 			},
 			bl_csau_mochamike = {
 				name="Mocha Mike",
 				text={
-					"#1# will not score"
+					"{C:attention}#1#{} will not score"
 				},
 			},
 			bl_csau_paint = {
 				name="The Paint",
 				text={
 					"Scoring cards change",
-					"suits randomly"
+					"{C:attention}suits{} randomly"
 				},
 			},
 			bl_csau_wasp = {
 				name = "The Wasp",
 				text = {
-					"Cards cannot retrigger"
+					"Cards cannot {C:attention}retrigger{}"
 				},
 			},
 			bl_csau_feltfortress = {
 				name = "Felt Fortress",
 				text = {
-					"Blind requirement doubles",
+					"{C:attention}Blind{} requirement {C:attention}doubles{}",
 					"after each hand scored"
 				},
 			},


### PR DESCRIPTION
- Updated all custom Blinds for compatibility with Fanworks mod's extra blinds feature
  - Mocha Mike and The Finger now use the `build in most_played_poker_hand` variable used by The Ox
  - The Wasp and The Vod function hooks now checks for `G.GAME.fnwk_extra_blinds`
  - Felt Fortress now tracks played hands and reverts them using an exponent on disable. This also fixes a bug where previously the backup score wasn't being saved, and so would crash on reload
  - Added color styled Blind descriptions for info box purposes