### PR TITLE
Moody Blues fix

### DIFF
--- a/includes/hooks/card.lua
+++ b/includes/hooks/card.lua
@@ -238,6 +238,13 @@ function Card:set_ability(center, initial, delay_sprites)
     end
 
     if self.ability.set == 'VHS' then
+        if self.config.center.discovered and not (G.OVERLAY_MENU or G.STAGE == G.STAGES.MAIN_MENU) then
+            local moodies = SMODS.find_card("c_csau_vento_moody")
+            for _, v in ipairs(moodies) do
+                self.ability.extra.runtime = self.ability.extra.runtime*2
+            end
+        end
+        
         self.no_shadow = true
     end
 

--- a/includes/items.lua
+++ b/includes/items.lua
@@ -288,11 +288,13 @@ local itemsToLoad = {
         'varuna',
         'planet_whirlpool',
         'planet_lost',
+        
         -- Spectral
         'quixotic',
+        'protojoker',
         'spec_stone',
         'spec_diary',
-        'protojoker',
+
         -- Tarot
         'tarot_arrow',
         'banned_consumables',

--- a/items/stands/steel_d4c.lua
+++ b/items/stands/steel_d4c.lua
@@ -67,6 +67,7 @@ function consumInfo.calculate(self, card, context)
             return true
         end
     end
+
     if context.end_of_round and not bad_context then
         card.ability.extra.hands_played = {}
     end
@@ -74,10 +75,16 @@ end
 
 
 function consumInfo.update(self, card)
-    if not card.area.config.collection and card.area == G.consumeables and to_big(get_lucky()) >= to_big(card.ability.extra.evolve_num) and not card.ability.evolved then
-        check_for_unlock({ type = "evolve_d4c" })
-        card.ability.evolved = true
-        G.FUNCS.csau_evolve_stand(card)
+    if card.area == nil or card.area.config.collection or card.area ~= G.consumeables then return end
+
+    if card.ability.d4c_evolve_queued then return end
+
+    if to_big(get_lucky()) >= to_big(card.ability.extra.evolve_num) then
+        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0, func = function()
+			check_for_unlock({ type = "evolve_d4c" })
+            card.ability.d4c_evolve_queued = true
+            G.FUNCS.csau_evolve_stand(card)
+        return true end}))
     end
 end
 

--- a/items/stands/vento_moody.lua
+++ b/items/stands/vento_moody.lua
@@ -21,8 +21,8 @@ function consumInfo.loc_vars(self, info_queue, card)
 end
 
 function consumInfo.add_to_deck(self, card)
-    for i, v in ipairs(G.consumeables.cards) do
-        if v.ability.set == "VHS" and (v.ability.extra and v.ability.extra.runtime) then
+    for _, v in ipairs(G.I.CARD) do
+        if v.ability and v.ability.set == "VHS" and (v.ability.extra and v.ability.extra.runtime) then
             v.ability.extra.runtime = v.ability.extra.runtime * 2
             G.FUNCS.csau_flare_stand_aura(card, 0.38)
         end
@@ -30,8 +30,8 @@ function consumInfo.add_to_deck(self, card)
 end
 
 function consumInfo.remove_from_deck(self, card)
-    for i, v in ipairs(G.consumeables.cards) do
-        if v.ability.set == "VHS" and (v.ability.extra and v.ability.extra.runtime) then
+    for _, v in ipairs(G.I.CARD) do
+        if v.ability and v.ability.set == "VHS" and (v.ability.extra and v.ability.extra.runtime) then
             v.ability.extra.runtime = v.ability.extra.runtime / 2
         end
     end

--- a/items/vhs/alienpi.lua
+++ b/items/vhs/alienpi.lua
@@ -31,12 +31,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.x_mult, card.ability.extra.chance_mod, G.FUNCS.csau_add_chance(card.ability.extra.chance, {multiply = true}), card.ability.extra.rate, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.individual and context.cardarea == G.play and not card.debuff then
         if context.other_card then

--- a/items/vhs/blackspine.lua
+++ b/items/vhs/blackspine.lua
@@ -6,6 +6,9 @@ local consumInfo = {
     nosleeve = true,
     config = {
         use_activate = true,
+        extra = {
+            runtime = 1
+        }
     },
     origin = 'rlm',
     origin = {

--- a/items/vhs/blooddebts.lua
+++ b/items/vhs/blooddebts.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.interest, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     local bad_context = context.repetition or context.individual or context.blueprint
     if card.ability.activated and context.starting_shop and not card.debuff and not bad_context then

--- a/items/vhs/calibighunks.lua
+++ b/items/vhs/calibighunks.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.before and not card.debuff and not context.blueprint and G.FUNCS.hand_contains_rank(context.scoring_hand, {13}) then
         for i, v in ipairs(context.scoring_hand) do

--- a/items/vhs/choppingmall.lua
+++ b/items/vhs/choppingmall.lua
@@ -25,13 +25,12 @@ function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_steel
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.wario } }
-    return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
-end
-
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
+    return { 
+        vars = {
+            card.ability.extra.runtime-card.ability.extra.uses,
+            (card.ability.extra.runtime-card.ability.extra.uses) > 1 and 's' or ''
+        }
+    }
 end
 
 function consumInfo.calculate(self, card, context)

--- a/items/vhs/devilstory.lua
+++ b/items/vhs/devilstory.lua
@@ -24,13 +24,12 @@ local consumInfo = {
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gong } }
-    return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
-end
-
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
+    return { 
+        vars = {
+            card.ability.extra.runtime-card.ability.extra.uses,
+            (card.ability.extra.runtime-card.ability.extra.uses) > 1 and 's' or ''
+        }
+    }
 end
 
 function consumInfo.calculate(self, card, context)

--- a/items/vhs/donbeveridge.lua
+++ b/items/vhs/donbeveridge.lua
@@ -27,12 +27,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 local ref_fe = SMODS.food_expires
 SMODS.food_expires = function(context)
     local bagels = G.FUNCS.find_activated_tape('c_csau_donbeveridge')

--- a/items/vhs/doubledown.lua
+++ b/items/vhs/doubledown.lua
@@ -23,12 +23,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.x_mult, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if context.joker_main and card.ability.activated then
         return {

--- a/items/vhs/exploding.lua
+++ b/items/vhs/exploding.lua
@@ -24,13 +24,12 @@ local consumInfo = {
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.rerun } }
-    return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
-end
-
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
+    return { 
+        vars = {
+            card.ability.extra.runtime-card.ability.extra.uses,
+            (card.ability.extra.runtime-card.ability.extra.uses) > 1 and 's' or ''
+        }
+    }
 end
 
 function consumInfo.calculate(self, card, context)

--- a/items/vhs/fatefulfindings.lua
+++ b/items/vhs/fatefulfindings.lua
@@ -22,12 +22,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 local function find_first_card(cards)
     for i, v in ipairs(cards) do
         if v.ability.set == 'Tarot' or v.ability.set == 'Planet' or v.ability.set == 'Spectral' then

--- a/items/vhs/ishtar.lua
+++ b/items/vhs/ishtar.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.chips, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and  context.individual and context.cardarea == G.play and not card.debuff then
         if context.other_card:get_id() == 4 or context.other_card:get_id() == 3 or context.other_card:get_id() == 2 then

--- a/items/vhs/kidsand.lua
+++ b/items/vhs/kidsand.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.discard_mod, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.setting_blind and not card.getting_sliced and not card.debuff then
         ease_discard(card.ability.extra.discard_mod)

--- a/items/vhs/lowblow.lua
+++ b/items/vhs/lowblow.lua
@@ -24,12 +24,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.retrigger, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 local function get_lowest_card(hand)
     local lowest_card = nil
     local lowest_value = math.huge

--- a/items/vhs/macandme.lua
+++ b/items/vhs/macandme.lua
@@ -24,12 +24,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.cardarea == G.play and context.repetition and not context.repetition_only then
         if (context.scoring_hand[1] and context.other_card == context.scoring_hand[1]) or (context.scoring_hand[2] and context.other_card == context.scoring_hand[2]) then

--- a/items/vhs/miami.lua
+++ b/items/vhs/miami.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.draw_mod, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.can_use(self, card)
     if to_big(#G.consumeables.cards) < to_big(G.consumeables.config.card_limit) or card.area == G.consumeables then return true end
 end

--- a/items/vhs/nukie.lua
+++ b/items/vhs/nukie.lua
@@ -24,12 +24,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if context.using_consumeable then
         if context.consumeable.config.center.key == 'c_wheel' then

--- a/items/vhs/osteo.lua
+++ b/items/vhs/osteo.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.setting_blind and not card.getting_sliced and not card.debuff then
         ease_hands_played(1)

--- a/items/vhs/rawtime.lua
+++ b/items/vhs/rawtime.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.cardarea == G.play and context.repetition and not context.repetition_only then
         if context.other_card:get_id() == 4 or context.other_card:get_id() == 7 or context.other_card:get_id() == 2 then

--- a/items/vhs/remlezar.lua
+++ b/items/vhs/remlezar.lua
@@ -17,16 +17,15 @@ local consumInfo = {
     origin = 'vinny'
 }
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.greeky } }
-    return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
+    return { 
+        vars = {
+            card.ability.extra.runtime-card.ability.extra.uses,
+            (card.ability.extra.runtime-card.ability.extra.uses) > 1 and 's' or ''
+        }
+    }
 end
 
 function consumInfo.can_use(self, card)

--- a/items/vhs/rentafriend.lua
+++ b/items/vhs/rentafriend.lua
@@ -24,13 +24,12 @@ local consumInfo = {
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.burlap } }
-    return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
-end
-
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
+    return { 
+        vars = {
+            card.ability.extra.runtime-card.ability.extra.uses,
+            (card.ability.extra.runtime-card.ability.extra.uses) > 1 and 's' or ''
+        }
+    }
 end
 
 function consumInfo.calculate(self, card, context)

--- a/items/vhs/ritf.lua
+++ b/items/vhs/ritf.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 local pi_digits = "314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172"
 
 local function get_pi_digit(i)

--- a/items/vhs/roar.lua
+++ b/items/vhs/roar.lua
@@ -26,12 +26,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.can_use(self, card)
     if to_big(#G.consumeables.cards) < to_big(G.consumeables.config.card_limit) or card.area == G.consumeables then return true end
 end

--- a/items/vhs/ryansbabe.lua
+++ b/items/vhs/ryansbabe.lua
@@ -24,12 +24,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.before and not card.debuff and not context.blueprint and G.FUNCS.hand_contains_rank(context.scoring_hand, {12}) then
         for i, v in ipairs(context.scoring_hand) do

--- a/items/vhs/sataniccults.lua
+++ b/items/vhs/sataniccults.lua
@@ -29,12 +29,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.xmult, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.individual and context.cardarea == G.hand and not context.final_scoring_step then
         if SMODS.has_enhancement(context.other_card, 'm_gold') then

--- a/items/vhs/sew.lua
+++ b/items/vhs/sew.lua
@@ -24,13 +24,12 @@ local consumInfo = {
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.yunkie } }
-    return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
-end
-
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
+    return { 
+        vars = {
+            card.ability.extra.runtime-card.ability.extra.uses,
+            (card.ability.extra.runtime-card.ability.extra.uses) > 1 and 's' or ''
+        }
+    }
 end
 
 function consumInfo.can_use(self, card)

--- a/items/vhs/shakma.lua
+++ b/items/vhs/shakma.lua
@@ -27,12 +27,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 local blacklisted_seeds = {
     '',
 }

--- a/items/vhs/sos.lua
+++ b/items/vhs/sos.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { G.GAME.probabilities.normal, card.ability.extra.prob, card.ability.extra.x_mult, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if context.joker_main and card.ability.activated and pseudorandom('cult') < G.GAME.probabilities.normal / card.ability.extra.prob then
         return {

--- a/items/vhs/spacecop.lua
+++ b/items/vhs/spacecop.lua
@@ -24,12 +24,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { G.GAME.probabilities.normal, card.ability.extra.prob, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.modify_level_increment and context.card then
         if context.card.ability.set == 'Planet' and card.ability then

--- a/items/vhs/streetsmarts.lua
+++ b/items/vhs/streetsmarts.lua
@@ -27,13 +27,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.yumz } }
     return { vars = { card.ability.extra.mult, card.ability.extra.runtime-card.ability.extra.uses } }
 end
-
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.joker_main and G.GAME.current_round.hands_left == 0 then
         return {

--- a/items/vhs/suburbansasquatch.lua
+++ b/items/vhs/suburbansasquatch.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.inc, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.final_scoring_step then
         G.E_MANAGER:add_event(Event({

--- a/items/vhs/supershow.lua
+++ b/items/vhs/supershow.lua
@@ -23,12 +23,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.remove_playing_cards then
         local emp_area = G.play

--- a/items/vhs/swhs.lua
+++ b/items/vhs/swhs.lua
@@ -23,12 +23,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.dollars, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.individual and context.cardarea == G.play then
         return {

--- a/items/vhs/tbone.lua
+++ b/items/vhs/tbone.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.mult, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.other_joker then
         G.E_MANAGER:add_event(Event({

--- a/items/vhs/theroom.lua
+++ b/items/vhs/theroom.lua
@@ -23,12 +23,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { 100*card.ability.extra.blind_mod, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.setting_blind and not card.getting_sliced and not card.debuff then
         G.E_MANAGER:add_event(Event({

--- a/items/vhs/topslots.lua
+++ b/items/vhs/topslots.lua
@@ -34,12 +34,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.conv_money, card.ability.extra.conv_score, card.ability.extra.max_initial_money, G.GAME.probabilities.normal, card.ability.extra.prob_double, card.ability.extra.prob_triple, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     local bad_context = context.repetition or context.individual or context.blueprint
     if card.ability.activated and context.end_of_round and not card.debuff and not bad_context then

--- a/items/vhs/troll2.lua
+++ b/items/vhs/troll2.lua
@@ -24,12 +24,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.before and not card.debuff and not context.blueprint then
         local eligable_cards = {}

--- a/items/vhs/twistedpair.lua
+++ b/items/vhs/twistedpair.lua
@@ -22,12 +22,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if card.ability.activated and context.before and not card.debuff and not context.blueprint then
         G.E_MANAGER:add_event(Event({

--- a/items/vhs/wwvcr.lua
+++ b/items/vhs/wwvcr.lua
@@ -28,12 +28,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.chips, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     if context.joker_main and card.ability.activated then
         return {

--- a/items/vhs/yoyoman.lua
+++ b/items/vhs/yoyoman.lua
@@ -27,12 +27,6 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-function consumInfo.set_ability(self, card, initial, delay_sprites)
-    if next(SMODS.find_card("c_csau_moodyblues")) then
-        card.ability.extra.runtime = card.ability.extra.runtime*2
-    end
-end
-
 function consumInfo.calculate(self, card, context)
     local bad_context = context.repetition or context.individual or context.blueprint
     if context.after and not card.ability.destroyed and card.ability.activated and not bad_context then

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -2597,7 +2597,7 @@ return {
 				text = {
 					"While {C:attention}playing{}, {C:spectral}Spectral{} Cards",
 					"cannot lower your hand size",
-					"{C:vhs}Running Time{}: {C:attention}#1#{} Card"
+					"{C:vhs}Running Time{}: {C:attention}#1#{} Card#2#"
 				},
 			},
 			c_csau_sew = {
@@ -2605,7 +2605,7 @@ return {
 				text = {
 					"While {C:attention}playing{}, will {C:attention}take the hit{} for",
 					"the next Joker to be destroyed",
-					"{C:vhs}Running Time{}: {C:attention}#1#{} Joker"
+					"{C:vhs}Running Time{}: {C:attention}#1#{} Joker#2#"
 				},
 			},
 			c_csau_shakma = {
@@ -2638,7 +2638,7 @@ return {
 				text = {
 					"While {C:attention}playing{}, turn all but one {C:blue}Hands",
 					"into {C:red}Discards{} when {C:attention}Blind{} is selected",
-					"{C:vhs}Running Time{}: {C:attention}#1#{} Round"
+					"{C:vhs}Running Time{}: {C:attention}#1#{} Round#2#"
 				},
 			},
 			c_csau_choppingmall = {
@@ -2647,7 +2647,7 @@ return {
 					"While {C:attention}playing{}, if {C:attention}scoring hand{} has",
 					"{C:attention}Steel Cards{} at the start and end",
 					"of the hand, add {C:red}Red Seals{} to both",
-					"{C:vhs}Running Time{}: {C:attention}#1#{} Hand"
+					"{C:vhs}Running Time{}: {C:attention}#1#{} Hand#2#"
 				},
 			},
 			c_csau_roar = {
@@ -2758,7 +2758,7 @@ return {
 				text = {
 					"While {C:attention}playing{}, add {C:money}Gold Seals{} to",
 					"all {C:attention}Enhanced{} cards in scoring hand",
-					"{C:vhs}Running Time{}: {C:attention}#1#{} Hand"
+					"{C:vhs}Running Time{}: {C:attention}#1#{} Hand#2#"
 				},
 			},
 			c_csau_rentafriend = {
@@ -2766,7 +2766,7 @@ return {
 				text = {
 					"While {C:attention}playing{}, all Jokers in ",
 					"shop are {C:money}Rental{} and {C:dark_edition}Negative{}",
-					"{C:vhs}Running Time{}: {C:attention}#1#{} Joker"
+					"{C:vhs}Running Time{}: {C:attention}#1#{} Joker#2#"
 				},
 			},
 			c_csau_tbone = {


### PR DESCRIPTION
- Moody Blues now universally doubles the running time of all VHS tapes regardless of when it is added to your deck
- Updated multiple VHS tapes to pluralize their running time if it's doubled from 1 to 2 (or higher)
- Fixed a crash with D4C on the startup screen