### PR TITLE
2.1 Bugfixes

### DIFF
--- a/includes/hooks/button_callbacks.lua
+++ b/includes/hooks/button_callbacks.lua
@@ -10,6 +10,10 @@ SMODS.Sound({
 
 local ref_check_buy_space = G.FUNCS.check_for_buy_space
 G.FUNCS.check_for_buy_space = function(card)
+    if card.config.center.key == 'j_csau_ufo' then
+        return true
+    end
+    
     local ret = ref_check_buy_space(card)
     if not ret then
         return ret

--- a/includes/hooks/misc_functions.lua
+++ b/includes/hooks/misc_functions.lua
@@ -130,3 +130,24 @@ function set_profile_progress()
 	end
 	G.PROFILES[G.SETTINGS.profile].progress.stand_stickers = copy_table(G.PROGRESS.stand_stickers)
 end
+
+
+function get_flush(hand, sub_count)
+  local ret = {}
+  local suits = SMODS.Suit.obj_buffer
+  if #hand < (5 - (math.min(sub_count, 4) or 0)) then return ret else
+    for j = 1, #suits do
+      local t = {}
+      local suit = suits[j]
+      local flush_count = 0
+      for i=1, #hand do
+        if hand[i]:is_suit(suit, nil, true) then flush_count = flush_count + 1;  t[#t+1] = hand[i] end 
+      end
+      if flush_count >= (5 - (math.min(sub_count, 4) or 0)) then
+        table.insert(ret, t)
+        return ret
+      end
+    end
+    return {}
+  end
+end

--- a/includes/hooks/smods.lua
+++ b/includes/hooks/smods.lua
@@ -64,6 +64,13 @@ SMODS.PokerHandPart:take_ownership('_straight', {
 	func = function(hand) return get_straight(hand, next(SMODS.find_card('j_four_fingers')) and 4 or 5, not not next(SMODS.find_card('j_shortcut')), next(SMODS.find_card('j_csau_gnorts'))) end
 })
 
+SMODS.PokerHandPart:take_ownership('_flush', {
+	func = function(hand)
+		local sub_count = (next(SMODS.find_card('j_four_fingers')) or next(SMODS.find_card('c_csau_lands_bigmouth'))) and 1 or 0
+		return get_flush(hand, sub_count)
+	end,
+})
+
 local ref_ccuib = SMODS.card_collection_UIBox
 SMODS.card_collection_UIBox = function(_pool, rows, args)
 	if _pool == G.P_CENTER_POOLS.csau_Stand then

--- a/items/jokers/ufo.lua
+++ b/items/jokers/ufo.lua
@@ -1,3 +1,4 @@
+
 local jokerInfo = {
     name = "UFO COMODIN",
     config = {

--- a/items/jokers/ufo.lua
+++ b/items/jokers/ufo.lua
@@ -21,7 +21,34 @@ local jokerInfo = {
 function jokerInfo.loc_vars(self, info_queue, card)
 	info_queue[#info_queue+1] = G.P_TAGS.tag_negative
     info_queue[#info_queue+1] = {key = "csau_artistcredit_2", set = "Other", vars = { G.csau_team.gote, G.csau_team.ele } }
-    return { vars = { card.ability.ufo_rounds, card.ability.extra } }
+    
+    local main_end = nil
+    if card.ability.card_key then
+        local name_text = localize{type = 'name_text', key = card.ability.card_key, set = 'Joker'}
+        main_end = {
+            {n=G.UIT.C, config={align = "bm", padding = 0.05}, nodes={
+                {n=G.UIT.C, config={align = "m", colour = G.C.BLACK, r = 0.05, padding = 0.05}, nodes={{
+                        n=G.UIT.T,
+                        config={text = ' '..name_text..' ', colour = G.C.UI.TEXT_LIGHT, scale = 0.3, shadow = true}
+                    }, {
+                        n=G.UIT.T,
+                        config={text = '[', colour = G.C.UI.TEXT_LIGHT, scale = 0.3, shadow = true}
+                    }, {
+                        n=G.UIT.T,
+                        config={text = card.ability.ufo_rounds, colour = G.C.FILTER, scale = 0.3, shadow = true}
+                    }, {
+                        n=G.UIT.T,
+                        config={text = '/'..card.ability.extra..'] ', colour = G.C.UI.TEXT_LIGHT, scale = 0.3, shadow = true}
+                    }
+                }}
+            }}
+        }
+    end
+    
+    return { 
+        vars = { card.ability.extra },
+        main_end = main_end
+    }
 end
 
 function jokerInfo.add_to_deck(self, card)

--- a/items/stands/diamond_killer.lua
+++ b/items/stands/diamond_killer.lua
@@ -37,31 +37,46 @@ end
 
 function consumInfo.calculate(self, card, context)
     local bad_context = context.repetition or context.blueprint or context.individual or context.retrigger_joker
+    
     if context.remove_playing_cards and not bad_context then
         local hands = 0
-        for i, _card in ipairs(context.removed) do
+        for i, _ in ipairs(context.removed) do
             check_for_unlock({ type = "destroy_killer" })
             hands = hands + card.ability.extra.hand_mod
         end
-        card.ability.extra.hands = hands
+        card.ability.extra.hands = card.ability.extra.hands + hands
         card.ability.extra.evolve_cards = card.ability.extra.evolve_cards + hands
         if to_big(card.ability.extra.evolve_cards) >= to_big(card.ability.extra.evolve_num) then
             check_for_unlock({ type = "evolve_btd" })
             G.FUNCS.csau_evolve_stand(card)
             return
         end
-        card:juice_up()
+        
+        G.FUNCS.csau_flare_stand_aura(card, 0.38)
+        G.E_MANAGER:add_event(Event({func = function()
+            play_sound('generic1')
+            card:juice_up()
+            return true
+        end }))
     end
-    if context.setting_blind and not card.debuff and card.ability.extra.hands > 0 then
-        if not (context.blueprint_card or card).getting_sliced then
-            G.E_MANAGER:add_event(Event({func = function()
-                ease_hands_played(card.ability.extra.hands)
+
+    if context.setting_blind and not bad_context and card.ability.extra.hands > 0 then
+        return {
+            func = function()
                 G.FUNCS.csau_flare_stand_aura(card, 0.38)
-                card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = "+"..card.ability.extra.hands.." "..localize('k_hud_hands')})
-                card.ability.extra.hands = 0
-                return true
-            end }))
-        end
+                ease_hands_played(card.ability.extra.hands)
+            end,
+            extra = {
+                message = localize{type = 'variable', key = 'a_hands', vars = {card.ability.extra.hands}}
+            }
+        }
+    end
+
+    if context.end_of_round and not bad_context and G.GAME.blind:get_type() == 'Boss' and card.ability.extra.hands > 0 then
+        card.ability.extra.hands = 0
+        return {
+            message = localize('k_reset'),
+        }
     end
 end
 

--- a/items/stands/lands_bigmouth.lua
+++ b/items/stands/lands_bigmouth.lua
@@ -33,49 +33,35 @@ function consumInfo.calculate(self, card, context)
 	if not context.before or #context.full_hand ~= card.ability.extra.hand_size or bad_context then return end
 
     -- record flip cards and do initial flip
-    local suit_list = {}
-    local target_key = nil
-    for _, hand_card in ipairs(context.full_hand) do
-        local suit_key = SMODS.Suits[hand_card.base.suit].key
+    if not next(context.poker_hands['Flush']) then return end
 
-        -- populate the suit keys
-        if not suit_list[suit_key] then suit_list[suit_key] = {} end
-        suit_list[suit_key][#suit_list[suit_key]+1] = hand_card
-
-        if #suit_list[suit_key] == card.ability.extra.suit_count then
-            target_key = suit_key
-        end
-    end
-
-    if not target_key then return end
-
+    local target_key = context.poker_hands['Flush'][1][1].base.suit
     local change_cards = {}
-    for k, v in pairs(suit_list) do
+    for k, v in pairs(context.full_hand) do
         -- find any cards not of the target transform key to transform
-        if k ~= target_key then
-            for _, change in ipairs(v) do
-                change_cards[#change_cards+1] = change
-                local suit = SMODS.Suits[target_key].card_key
-                local rank = SMODS.Ranks[change.base.value].card_key
-                change:set_base(G.P_CARDS[suit..'_'..rank], nil, true)
+        if v.base.suit ~= target_key then
+            local change = v
+            change_cards[#change_cards+1] = change
+            local suit = SMODS.Suits[target_key].card_key
+            local rank = SMODS.Ranks[change.base.value].card_key
+            change:set_base(G.P_CARDS[suit..'_'..rank], nil, true)
 
-                G.E_MANAGER:add_event(Event({
-                    trigger = 'after',
-                    delay = 0.15,
-                    func = function()
-                        change:flip()
-                        play_sound('card1')
-                        change:juice_up(0.3, 0.3)
-                        return true 
-                    end 
-                }))
-            end
+            G.E_MANAGER:add_event(Event({
+                trigger = 'after',
+                delay = 0.15,
+                func = function()
+                    change:flip()
+                    play_sound('card1')
+                    change:juice_up(0.3, 0.3)
+                    return true 
+                end 
+            }))
         end
     end
 
     if #change_cards < 1 then return end
 
-    G.FUNCS.csau_flare_stand_aura(card, 0.38)
+    G.FUNCS.csau_flare_stand_aura(card, 0.5)
     card_eval_status_text(card, 'extra', nil, nil, nil, {
         message = localize(target_key, 'suits_plural'),
         colour = G.C.SUITS[target_key]
@@ -105,7 +91,6 @@ function consumInfo.calculate(self, card, context)
             end 
         }))
     end
-
 end
 
 

--- a/items/stands/steel_civil.lua
+++ b/items/stands/steel_civil.lua
@@ -1,3 +1,113 @@
+local function force_fool_card()
+    if G.consumeables then
+        return next(SMODS.find_card('c_csau_steel_civil')) and 'c_hanged_man' or nil
+    end
+
+    return nil
+end
+
+
+SMODS.Consumable:take_ownership('c_fool', {
+    loc_vars = function(self, info_queue, card)
+        local fool_c = G.GAME.last_tarot_planet and G.P_CENTERS[G.GAME.last_tarot_planet] or nil
+
+        local force_card = force_fool_card()
+        if force_card then fool_c = G.P_CENTERS[force_card] end
+        
+        -- imported cardsauce logic
+        local last_tarot_planet = localize('k_none')
+        if fool_c and fool_c.key == 'c_csau_arrow' then
+            last_tarot_planet = fool_c and localize{type = 'name_text', key = fool_c.key, set = fool_c.set, vars = { G.GAME.csau_max_stands or 1, (card.area.config.collection and localize('k_csau_stand')) or (G.GAME.csau_max_stands > 1 and localize('b_csau_stand_cards') or localize('k_csau_stand')) }} or localize('k_none')
+        else
+            last_tarot_planet = fool_c and localize{type = 'name_text', key = fool_c.key, set = fool_c.set} or localize('k_none')
+        end
+
+        local colour = (not fool_c or fool_c.name == 'The Fool') and G.C.RED or G.C.GREEN
+        local main_end = {
+            {n=G.UIT.C, config={align = "bm", padding = 0.02}, nodes={
+                {n=G.UIT.C, config={align = "m", colour = colour, r = 0.05, padding = 0.05}, nodes={
+                    {n=G.UIT.T, config={text = ' '..last_tarot_planet..' ', colour = G.C.UI.TEXT_LIGHT, scale = 0.3, shadow = true}},
+                }}
+            }}
+        }
+        if not (not fool_c or fool_c.name == 'The Fool') then
+            info_queue[#info_queue+1] = fool_c
+        end
+
+        return { vars = {last_tarot_planet}, main_end = main_end }
+    end,
+
+    use = function(self, card, area, copier)
+        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
+            if G.consumeables.config.card_limit > #G.consumeables.cards then
+                play_sound('timpani')
+
+                local found_card = force_fool_card()
+                if not found_card then
+                    found_card = G.GAME.last_tarot_planet
+                end
+                local card = create_card('Tarot_Planet', G.consumeables, nil, nil, nil, nil, found_card, 'fool')
+                card:add_to_deck()
+                G.consumeables:emplace(card)
+                card:juice_up(0.3, 0.5)
+            end
+            return true end }))
+        delay(0.6)
+    end,
+
+    can_use = function(self, card)
+        local force_card = force_fool_card()
+        if force_card then return true end
+
+        local has_space = #G.consumeables.cards < G.consumeables.config.card_limit or card.area == G.consumeables
+        return (has_space and G.GAME.last_tarot_planet and G.GAME.last_tarot_planet ~= 'c_fool')
+    end
+}, true)
+
+SMODS.Consumable:take_ownership('c_emperor', {
+    loc_vars = function (self, info_queue, card)
+        local tarot_count = self.config.tarots
+        local found_card = force_fool_card()
+        if found_card then 
+            tarot_count = tarot_count - 1
+            info_queue[#info_queue+1] = G.P_CENTERS[found_card]
+        end
+        tarot_count = math.max(0, tarot_count)
+        
+        return { 
+            vars = { tarot_count },
+            key = self.key..(found_card and '_civil' or '')
+        }
+    end,
+
+    use = function(self, card, area, copier)
+        local tarot_count = self.config.tarots
+        local found_card = force_fool_card()
+
+        sendDebugMessage('tarot count: '..tarot_count)
+        sendDebugMessage('space: '..tostring(G.consumeables.config.card_limit - #G.consumeables.cards))
+        for i = 1, math.min(tarot_count, G.consumeables.config.card_limit - #G.consumeables.cards) do
+            local force_key = i==1 and found_card
+            G.E_MANAGER:add_event(Event({
+                trigger = 'after',
+                delay = 0.4,
+                func = function()
+                    if G.consumeables.config.card_limit > #G.consumeables.cards then
+                        play_sound('timpani')
+                        local new_tarot = create_card('Tarot', G.consumeables, nil, nil, nil, nil, force_key, 'emp')
+                        new_tarot:add_to_deck()
+                        G.consumeables:emplace(new_tarot)
+                        card:juice_up(0.3, 0.5)
+                        sendDebugMessage('checking space: '..tostring(G.consumeables.config.card_limit - #G.consumeables.cards))
+                    end
+                    return true    
+                end
+            }))
+        end
+        delay(0.6)
+    end
+}, true)
+
 local consumInfo = {
     name = 'Civil War',
     set = 'csau_Stand',
@@ -17,7 +127,7 @@ local consumInfo = {
 }
 
 function consumInfo.loc_vars(self, info_queue, card)
-    info_queue[#info_queue+1] = G.P_CENTERS.c_fool
+    info_queue[#info_queue+1] = G.P_CENTERS.c_hanged_man
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
     return { vars = {localize{type = 'name_text', key = card.ability.extra.tarot, set = 'Tarot'}}}
 end
@@ -32,7 +142,5 @@ function consumInfo.calculate(self, card, context)
         end
     end
 end
-
-
 
 return consumInfo

--- a/items/stands/stone_white_moon.lua
+++ b/items/stands/stone_white_moon.lua
@@ -1,4 +1,5 @@
 local consumInfo = {
+    key = 'c_csau_stone_white_moon',
     name = 'C-MOON',
     set = 'csau_Stand',
     config = {
@@ -8,8 +9,8 @@ local consumInfo = {
         evolve_key = 'c_csau_stone_white_heaven',
         extra = {
             repetitions = 1,
-            evolve_ranks = 0,
-            evolve_num = 13,
+            evolve_moons = 0,
+            evolve_num = 4,
             ranks = {}
         }
     },
@@ -23,7 +24,11 @@ local consumInfo = {
 
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit_2", set = "Other", vars = { G.csau_team.wario, G.csau_team.gote } }
-    return { vars = {card.ability.extra.evolve_num}}
+    return { vars = {card.ability.extra.evolve_num - card.ability.extra.evolve_moons}}
+end
+
+function consumInfo.generate_ui(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
+    G.FUNCS.csau_generate_detail_desc(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
 end
 
 function consumInfo.in_pool(self, args)
@@ -39,55 +44,51 @@ function consumInfo.in_pool(self, args)
     return true
 end
 
-local function unique_ranks_check(card, new_rank, num)
-    card.ability.extra.ranks[new_rank] = true
-    local count = 0
-    for k, v in pairs(card.ability.extra.ranks) do
-        if v == true then count = count + 1 end
-    end
-    return count >= num
-end
-
 function consumInfo.calculate(self, card, context)
     local bad_context = context.repetition or context.blueprint or context.individual or context.retrigger_joker
-    if context.before and not card.debuff and not bad_context then
-        if next(context.poker_hands["Straight"]) then
-            local evolved = false
-            for k, v in ipairs(context.full_hand) do
-                if not v.debuff then
-                    evolved = unique_ranks_check(card, v.base.value, card.ability.extra.evolve_num)
-                end
-            end
-            if evolved then
-                check_for_unlock({ type = "evolve_heaven" })
-                G.FUNCS.csau_evolve_stand(card)
-            end
+    if context.using_consumeable and not card.debuff and not bad_context and context.consumeable.config.center.key == 'c_moon' then
+        
+        card.ability.extra.evolve_moons = card.ability.extra.evolve_moons + 1
+        if card.ability.extra.evolve_moons >= card.ability.extra.evolve_num then
+            G.FUNCS.csau_evolve_stand(card)
+            return
         end
+
+        return {
+            func = function()
+                G.FUNCS.csau_flare_stand_aura(card, 0.5)
+            end,
+            extra = {
+                message = localize{type='variable',key='a_remaining',vars={card.ability.extra.evolve_num - card.ability.extra.evolve_moons}},
+                colour = G.C.STAND,
+                delay = 1
+            }
+        }
     end
-    if context.cardarea == G.play and context.repetition and not context.repetition_only and not card.debuff then
-        if context.other_card:get_id() == 6 then
+
+    if context.cardarea == G.play and context.repetition and not card.debuff then
+        local reps = next(context.poker_hands["Straight"]) and 1 or 0
+        if context.other_card:get_id() == 6 then reps = reps + 1 end
+        
+        if reps > 0 then
+            G.FUNCS.csau_flare_stand_aura(card, 0.38)
+            G.E_MANAGER:add_event(Event({
+                trigger = 'immediate',
+                blocking = false,
+                func = function()
+                    card:juice_up()
+                    return true
+                end 
+            }))
+            
             return {
                 func = function()
-                    G.FUNCS.csau_flare_stand_aura(card, 0.38)
+                    -- 
                 end,
-                message = 'Again!',
-                repetitions = 1,
-                card = card
+                message = localize('k_again_ex'),
+                repetitions = card.ability.extra.repetitions * reps,
+                card = context.other_card
             }
-        end
-        if next(context.poker_hands["Straight"]) then
-            for k, v in ipairs(context.full_hand) do
-                if not v.debuff then
-                    return {
-                        func = function()
-                            G.FUNCS.csau_flare_stand_aura(card, 0.38)
-                        end,
-                        message = 'Again!',
-                        repetitions = card.ability.extra.repetitions,
-                        card = context.other_card
-                    }
-                end
-            end
         end
     end
 end

--- a/items/stands/vento_gold_requiem.lua
+++ b/items/stands/vento_gold_requiem.lua
@@ -45,7 +45,7 @@ function consumInfo.calculate(self, card, context)
                 level_up = true,
                 message = localize('k_level_up_ex')
             }
-        
+        end
     end
 end
 

--- a/items/vhs/choppingmall.lua
+++ b/items/vhs/choppingmall.lua
@@ -1,6 +1,19 @@
+local ref_game_update_hand = Game.update_selecting_hand
+function Game:update_selecting_hand(dt)
+    local state_complete = G.STATE_COMPLETE
+
+    local ret = ref_game_update_hand(self, dt)
+
+    if not state_complete and G.STATE_COMPLETE and #G.hand.cards >= 1 and #G.deck.cards >= 1 then
+        SMODS.calculate_context({csau_resetting_hand = true})
+    end
+
+    return ret
+end
+
 local consumInfo = {
     name = 'Chopping Mall',
-    key = 'choppingmall',
+    key = 'c_csau_choppingmall',
     set = "VHS",
     cost = 3,
     alerted = true,
@@ -9,7 +22,7 @@ local consumInfo = {
         activated = false,
         destroyed = false,
         extra = {
-            runtime = 1,
+            runtime = 3,
             uses = 0,
         },
     },
@@ -22,7 +35,6 @@ local consumInfo = {
 
 
 function consumInfo.loc_vars(self, info_queue, card)
-    info_queue[#info_queue+1] = G.P_CENTERS.m_steel
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.wario } }
     return { 
@@ -34,26 +46,42 @@ function consumInfo.loc_vars(self, info_queue, card)
 end
 
 function consumInfo.calculate(self, card, context)
-    if card.ability.activated and context.before and not card.debuff and not context.blueprint then
-        if context.scoring_hand[1] and SMODS.has_enhancement(context.scoring_hand[1], 'm_steel')
-        and context.scoring_hand[#context.scoring_hand] and SMODS.has_enhancement(context.scoring_hand[#context.scoring_hand], 'm_steel') then
-            for i = 1, 2 do
-                local _card = i==1 and context.scoring_hand[1] or context.scoring_hand[#context.scoring_hand]
-                G.E_MANAGER:add_event(Event({
-                    func = function()
-                        _card:juice_up()
-                        _card:set_seal("Red", nil, true)
-                        return true
-                    end
-                }))
-            end
-            card.ability.extra.uses = card.ability.extra.uses+1
-            if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
-                G.FUNCS.destroy_tape(card)
-                card.ability.destroyed = true
-            end
+    if not card.ability.activated then return end
+
+    if (context.csau_resetting_hand and G.GAME.current_round.hands_played > 0) or (context.end_of_round and context.game_over ~= nil) then
+        card.ability.extra.uses = card.ability.extra.uses + 1
+        if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
+            G.E_MANAGER:add_event(Event({
+                blocking = false,
+                func = function()
+                    G.FUNCS.destroy_tape(card)
+                    card.ability.destroyed = true
+                    return true
+                end 
+            }))
         end
+        return
     end
+
+    if not (context.repetition and context.cardarea == G.hand)
+    or not (next(context.card_effects[1]) or #context.card_effects > 1) then
+        return
+    end
+
+    G.E_MANAGER:add_event(Event({
+        trigger = 'immediate',
+        blocking = false,
+        func = function()
+            card:juice_up()
+            return true
+        end 
+    }))
+
+    return {
+        message = localize('k_again_ex'),
+        repetitions = 1,
+        card = card
+    }
 end
 
 function consumInfo.can_use(self, card)

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -3114,7 +3114,7 @@ return {
 					"{C:attention}Retrigger{} each played {C:attention}6{}",
 					"{C:attention}Retrigger{} each played {C:attention}Straight{}",
 					"{s:0.1} {}",
-					"{C:dark_edition}The time for Heaven has almost come...",
+					"{C:dark_edition,s:0.8}The time for Heaven has almost come...",
 				},
 			},
 			c_csau_stone_white_moon_detailed = {
@@ -3323,7 +3323,15 @@ return {
 					"This challenge bans all non-{C:clubs}Cardsauce{}",
 					"{C:attention}modded Consumables{}",
 				}
-			}
+			},
+			c_emperor_civil = {
+				name = "The Emperor",
+				text = {
+					"Creates {C:tarot}The Hanged Man{} and",
+                    "{C:attention}#1#{} random {C:tarot}Tarot{} card",
+                    "{C:inactive}(Must have room)"
+				}
+			},
 		},
 		Spectral = {
 			c_csau_quixotic = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -2494,9 +2494,8 @@ return {
 				name="UFO COMODIN",
 				text={
 					"Upon purchase, {C:attention}removes{} a random Joker",
-					"After {C:attention}#2#{} rounds, sell this card",
+					"After {C:attention}#1#{} rounds, sell this card",
 					"to return it {C:dark_edition}Negative{}",
-					"{C:inactive}(Currently {C:attention}#1#{C:inactive}/#2#)",
 				},
 			},
 			j_csau_wigsaw = {

--- a/lovely/stands.toml
+++ b/lovely/stands.toml
@@ -5,31 +5,6 @@ priority = 9999999
 
 [[patches]]
 [patches.pattern]
-target = "card.lua"
-pattern = "local card = create_card('Tarot_Planet', G.consumeables, nil, nil, nil, nil, G.GAME.last_tarot_planet, 'fool')"
-position = "at"
-payload = '''
-local card
-if next(SMODS.find_card("c_csau_steel_civil")) then
-    card = create_card('Tarot_Planet', G.consumeables, nil, nil, nil, nil, 'c_hanged_man', 'fool')
-else
-    card = create_card('Tarot_Planet', G.consumeables, nil, nil, nil, nil, G.GAME.last_tarot_planet, 'fool')
-end
-'''
-match_indent = true
-times = 1
-
-[[patches]]
-[patches.pattern]
-target = "functions/common_events.lua"
-pattern = "local fool_c = G.GAME.last_tarot_planet and G.P_CENTERS[G.GAME.last_tarot_planet] or nil"
-position = "at"
-payload = "local fool_c = ((next(SMODS.find_card('c_csau_steel_civil')) and G.P_CENTERS['c_hanged_man']) or G.GAME.last_tarot_planet and G.P_CENTERS[G.GAME.last_tarot_planet] or nil)"
-match_indent = true
-times = 1
-
-[[patches]]
-[patches.pattern]
 target = "functions/common_events.lua"
 pattern = "local mult = card:get_chip_mult()"
 position = "before"


### PR DESCRIPTION
# Fixes
- UFO COMODIN
  - Can be purchased with full joker slots
  - Displays the abducted Joker and round timer with a badge
- Bigmouth Strikes Again
  - Has a 4 Fingers effect for flushes
  - Turns all remaining cards into the flush suit (though in practicality, it only ever turns 1 card into the flush suit)
- Killer Queen
  - Gives hands every round within an ante that cards have been destroyed
  - Resets at the end of the ante similar to Campfire
- C-MOON
  - Evolve condition is now playing The Moon tarot cards
  - Fixed effect visual timing for the Stand aura flare
  - Fixed multiple "repetitions" being added at the end of a hand for odd reasons
- Civil War
  - The Emperor now gives The Hanged Man in addition to another card
  - Emperor now has a contextual description if Civil War is present
- Chopping Mall
  - Now has a Mime effect
  - Its uses tick up at the "beginning" of each new hand OR the end of the round, and it will destroy itself after end-of-round effects on its last hand
- Fixed a weird crash with Gold Experience? Syntax Error? What?