### PR TITLE
Achievement Fixes and Probability Overhaul

### DIFF
--- a/includes/achievements.lua
+++ b/includes/achievements.lua
@@ -72,10 +72,8 @@ function G.FUNCS.ach_vineshroom_check()
 end
 
 G.FUNCS.reset_trophies = function(e)
-	sendDebugMessage('resetting trophies')
 	local warning_text = e.UIBox:get_UIE_by_ID('warn')
 	if warning_text.config.colour ~= G.C.WHITE then
-		sendDebugMessage('warning')
 		warning_text:juice_up()
 		warning_text.config.colour = G.C.WHITE
 		warning_text.config.shadow = true
@@ -86,12 +84,9 @@ G.FUNCS.reset_trophies = function(e)
 			e.config.disable_button = nil;return true end}))
 		play_sound('tarot2', 1, 0.4)
 	else
-		sendDebugMessage('starting wipe')
 		G.FUNCS.wipe_on()
 		for k, v in pairs(SMODS.Achievements) do
-			sendDebugMessage('found achievement')
 			if starts_with(k, 'ach_csau_') then
-				sendDebugMessage('resetting achievement')
 				G.SETTINGS.ACHIEVEMENTS_EARNED[k] = nil
 				G.ACHIEVEMENTS[k].earned = nil
 			end

--- a/includes/achievements.lua
+++ b/includes/achievements.lua
@@ -72,8 +72,10 @@ function G.FUNCS.ach_vineshroom_check()
 end
 
 G.FUNCS.reset_trophies = function(e)
+	sendDebugMessage('resetting trophies')
 	local warning_text = e.UIBox:get_UIE_by_ID('warn')
 	if warning_text.config.colour ~= G.C.WHITE then
+		sendDebugMessage('warning')
 		warning_text:juice_up()
 		warning_text.config.colour = G.C.WHITE
 		warning_text.config.shadow = true
@@ -84,9 +86,12 @@ G.FUNCS.reset_trophies = function(e)
 			e.config.disable_button = nil;return true end}))
 		play_sound('tarot2', 1, 0.4)
 	else
+		sendDebugMessage('starting wipe')
 		G.FUNCS.wipe_on()
 		for k, v in pairs(SMODS.Achievements) do
+			sendDebugMessage('found achievement')
 			if starts_with(k, 'ach_csau_') then
+				sendDebugMessage('resetting achievement')
 				G.SETTINGS.ACHIEVEMENTS_EARNED[k] = nil
 				G.ACHIEVEMENTS[k].earned = nil
 			end

--- a/includes/hooks/common_events.lua
+++ b/includes/hooks/common_events.lua
@@ -1,0 +1,6 @@
+local ref_create_card = create_card
+function create_card(_type, area, legendary, _rarity, skip_materialize, soulable, forced_key, key_append)
+    local ret = ref_create_card(_type, area, legendary, _rarity, skip_materialize, soulable, forced_key, key_append)
+    SMODS.calculate_context({csau_created_card = ret, area = area})
+    return ret
+end

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -587,16 +587,12 @@ end
 G.FUNCS.csau_add_chance = function(num, extra)
 	local multiply = extra and extra.multiply or false
 	local startAtOne = extra and extra.start_at_one or false
-	if G.FUNCS.powers_active and G.FUNCS.powers_active() then
-		return 0
-	else
-		if multiply then
-			if G.GAME.probabilities and G.GAME.probabilities.normal then
-				return ((startAtOne and 1 or 0) + num) * G.GAME.probabilities.normal
-			end
+	if multiply then
+		if G.GAME.probabilities and G.GAME.probabilities.normal then
+			return ((startAtOne and 1 or 0) + num) * G.GAME.probabilities.normal
 		end
-		return (startAtOne and 1 or 0) + num
 	end
+	return (startAtOne and 1 or 0) + num
 end
 
 -- Based on code from Ortalab

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -1273,11 +1273,12 @@ end
 
 G.FUNCS.have_multiple_jokers = function(tbl, amount)
 	local found = 0
-	for i, v in ipairs(tbl) do
+	for _, v in ipairs(tbl) do
 		if next(SMODS.find_card(v)) then
 			found = found + 1
 		end
 	end
+	
 	if amount then
 		return found >= amount
 	else

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -1280,18 +1280,36 @@ G.FUNCS.have_multiple_jokers = function(tbl, amount)
 end
 
 local tag_colors = {
-	tag_uncommon = G.C.GREEN,
-	tag_rare = G.C.RED,
-	tag_negative = G.C.DARK_EDITION,
-	tag_foil = G.C.DARK_EDITION,
-	tag_holo = G.C.DARK_EDITION,
-	tag_polychrome = G.C.DARK_EDITION,
+    tag_uncommon = G.C.GREEN,
+    tag_rare = G.C.RED,
+    tag_negative = G.C.DARK_EDITION,
+    tag_foil = G.C.DARK_EDITION,
+    tag_holo = G.C.DARK_EDITION,
+    tag_polychrome = G.C.DARK_EDITION,
+    tag_investment = G.C.MONEY,
+    tag_voucher = G.C.SECONDARY_SET.Voucher,
+    tag_boss = G.C.IMPORTANT,
+    tag_standard = G.C.IMPORTANT,
+    tag_charm = G.C.SECONDARY_SET.Tarot,
+    tag_meteor = G.C.SECONDARY_SET.Planet,
+    tag_buffoon = G.C.RED,
+    tag_handy = G.C.MONEY,
+    tag_garbage = G.C.MONEY,
+    tag_ethereal = G.C.SECONDARY_SET.Spectral,
+    tag_coupon = G.C.MONEY,
+    tag_double = G.C.IMPORTANT,
+    tag_juggle = G.C.BLUE,
+    tag_d_six = G.C.GREEN,
+    tag_top_up = G.C.BLUE,
+    tag_skip = G.C.MONEY,
+    tag_orbital = G.C.SECONDARY_SET.Planet,
+    tag_economy = G.C.MONEY,
 }
 
-G.FUNCS.csau_get_free_tag = function(type, seed)
+G.FUNCS.csau_get_tag = function(type, seed)
 	type = type or 'joker'
 	seed = seed or 'freejokertag'
-	local _pool, _pool_key = get_current_pool('Tag', nil, nil, seed)
+	local _pool, _ = get_current_pool('Tag', nil, nil, seed)
 	local real_pool = {}
 	for i, v in ipairs(_pool) do
 		if v ~= "UNAVAILABLE" then
@@ -1306,7 +1324,7 @@ G.FUNCS.csau_get_free_tag = function(type, seed)
 		end
 	end
 	local key = pseudorandom_element(real_pool, pseudoseed(seed))
-	return key, G.P_TAGS[key], tag_colors[key] or G.C.IMPORTANT
+	return key, tag_colors[key] or G.C.IMPORTANT
 end
 
 G.FUNCS.nutbuster_active = function()

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -584,17 +584,6 @@ G.FUNCS.csau_all_suit = function(hand, suit)
 	return true
 end
 
-G.FUNCS.csau_add_chance = function(num, extra)
-	local multiply = extra and extra.multiply or false
-	local startAtOne = extra and extra.start_at_one or false
-	if multiply then
-		if G.GAME.probabilities and G.GAME.probabilities.normal then
-			return ((startAtOne and 1 or 0) + num) * G.GAME.probabilities.normal
-		end
-	end
-	return (startAtOne and 1 or 0) + num
-end
-
 -- Based on code from Ortalab
 --- Replaces a card in-place with a card of the specified key
 --- @param card Card Balatro card table of the card to replace
@@ -1108,9 +1097,17 @@ G.FUNCS.find_activated_tape = function(key)
 	return false
 end
 
-SMODS.food_expires = function(context)
-	if next(SMODS.find_card('j_csau_bunji')) then return false end
-	return true
+SMODS.food_expires = function()
+	local bunjis = SMODS.find_card('j_csau_bunji')
+	local expires = true
+	for _, v in ipairs(bunjis) do
+		if not v.debuff then
+			expires = true
+			break
+		end
+	end
+
+	return expires
 end
 
 SMODS.return_to_hand = function(card, context)

--- a/items/achievements/activate_claus.lua
+++ b/items/achievements/activate_claus.lua
@@ -1,9 +1,7 @@
 local trophyInfo = {
     rarity = 1,
     unlock_condition = function(self, args)
-        if args.type == "activate_claus" then
-            return true
-        end
+        return args.type == 'activate_claus'
     end,
 }
 

--- a/items/achievements/cardsauceplusplus.lua
+++ b/items/achievements/cardsauceplusplus.lua
@@ -16,7 +16,7 @@ local trophyInfo = {
                 local jokers = 0
                 local count = 0
                 for k, v in pairs(G.P_CENTERS) do
-                    if starts_with(k, 'j_csau_') and v.set == 'Joker' and not v.omit then
+                    if starts_with(k, 'j_csau_') and v.set == 'Joker' and not v.omit and not v.no_collection then
                         jokers = jokers + 1
                         count = count + get_joker_win_sticker(v, true)
                     end

--- a/items/achievements/destroy_meteor.lua
+++ b/items/achievements/destroy_meteor.lua
@@ -1,9 +1,7 @@
 local trophyInfo = {
     rarity = 1,
     unlock_condition = function(self, args)
-        if args.type == "destroy_meteor" then
-            return true
-        end
+        return args.type == 'destroy_meteor'
     end,
 }
 

--- a/items/achievements/gamer_blowzo.lua
+++ b/items/achievements/gamer_blowzo.lua
@@ -1,9 +1,7 @@
 local trophyInfo = {
     rarity = 1,
     unlock_condition = function(self, args)
-        if args.type == "gamer_blowzo" then
-            return true
-        end
+        return args.type == 'gamer_blowzo'
     end,
 }
 

--- a/items/achievements/high_horse.lua
+++ b/items/achievements/high_horse.lua
@@ -1,9 +1,7 @@
 local trophyInfo = {
     rarity = 2,
     unlock_condition = function(self, args)
-        if args.type == "high_horse" then
-            return true
-        end
+        return args.type == 'high_horse'
     end,
 }
 

--- a/items/achievements/high_one.lua
+++ b/items/achievements/high_one.lua
@@ -9,7 +9,7 @@ local trophyInfo = {
     rarity = 2,
     unlock_condition = function(self, args)
         if args.type == 'modify_jokers' and #G.jokers.cards > 0 then
-            return G.FUNCS.have_multiple_jokers(high_one_jokers, 4)
+            return G.FUNCS.have_multiple_jokers(high_one_jokers, 2)
         end
 
         return false

--- a/items/achievements/high_one.lua
+++ b/items/achievements/high_one.lua
@@ -1,15 +1,18 @@
+local high_one_jokers = {
+    'j_csau_besomeone',
+    'j_csau_pivot',
+    'j_csau_meat',
+    'j_csau_dontmind',
+}
+
 local trophyInfo = {
     rarity = 2,
     unlock_condition = function(self, args)
-        if G.jokers and #G.jokers.cards > 0 then
-            local jokers = {
-                'j_csau_besomeone',
-                'j_csau_pivyot',
-                'j_csau_meat',
-                'j_csau_dontmind',
-            }
-            return G.FUNCS.have_multiple_jokers(jokers, 4)
+        if args.type == 'modify_jokers' and #G.jokers.cards > 0 then
+            return G.FUNCS.have_multiple_jokers(high_one_jokers, 4)
         end
+
+        return false
     end,
 }
 

--- a/items/blinds/hog.lua
+++ b/items/blinds/hog.lua
@@ -17,7 +17,7 @@ function blindInfo.set_blind(self)
         v.csau_hogstruck = nil
         v.csau_hog_checked = nil
         if v:is_face(true) then
-            if pseudorandom(pseudoseed('csau_hog')) < G.GAME.probabilities.normal/2 then
+            if SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_hog'), 1, 2) then
                 v.csau_hogstruck = true
             end
             v.csau_hog_checked = true
@@ -41,7 +41,7 @@ function blindInfo.recalc_debuff(self, card, from_blind)
         return false
     elseif card:is_face(true) and not card.csau_hog_checked then
         card.csau_hog_checked = true
-        if pseudorandom(pseudoseed('csau_hog')) < G.GAME.probabilities.normal/2 then
+        if SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_hog'), 1, 2) then
             card.csau_hogstruck = true
             return true
         end
@@ -51,10 +51,10 @@ function blindInfo.recalc_debuff(self, card, from_blind)
 end
 
 function blindInfo.loc_vars(self)
-    return {vars = {G.GAME.probabilities.normal} }
+    return {vars = {SMODS.get_probability_vars(self, 1, 2)} }
 end
 function blindInfo.collection_loc_vars(self)
-    return {vars = {G.GAME.probabilities.normal} }
+    return {vars = {SMODS.get_probability_vars(self, 1, 2)} }
 end
 
 function blindInfo.defeat(self)
@@ -71,7 +71,7 @@ function blindInfo.press_play(self)
     G.E_MANAGER:add_event(Event({
         func = function()
             for i, v in ipairs(G.play.cards) do
-                if v.csau_hogstruck and pseudorandom(pseudoseed('csau_hogstrike')) < G.GAME.probabilities.normal/2 then
+                if v.csau_hogstruck and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_hog'), 1, 2) then
                     destroy = true
                     if v.ability.name == 'Glass Card' then
                         v:shatter()

--- a/items/blinds/tray.lua
+++ b/items/blinds/tray.lua
@@ -13,7 +13,7 @@ local blindInfo = {
 }
 
 function blindInfo.modify_hand(self, cards, poker_hands, text, mult, hand_chips)
-    if pseudorandom(pseudoseed('onequartertrayof')) < G.GAME.probabilities.normal/3 then
+    if SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_tray'), 1, 3) then
         self.triggered = true
         return math.max(math.floor(mult/3 + 0.5), 1), math.max(math.floor(hand_chips/3 + 0.5), 0), true
     end
@@ -21,10 +21,10 @@ function blindInfo.modify_hand(self, cards, poker_hands, text, mult, hand_chips)
 end
 
 function blindInfo.loc_vars(self)
-    return {vars = { G.GAME.probabilities.normal, 3 } }
+    return {vars = { SMODS.get_probability_vars(self, 1, 3) } }
 end
 function blindInfo.collection_loc_vars(self)
-    return {vars = { G.GAME.probabilities.normal, 3 } }
+    return {vars = { SMODS.get_probability_vars(self, 1, 3) } }
 end
 
 function blindInfo.defeat(self)

--- a/items/decks/varg.lua
+++ b/items/decks/varg.lua
@@ -1,33 +1,40 @@
 local deckInfo = {
     name = 'Varg Deck',
-    config = {},
     unlocked = false,
     discovered = false,
-    config = { hand_size = -1 },
+    config = { 
+        hand_size = -1,
+        probability_mod = 2
+    },
     unlock_condition = {type = 'win_deck', deck = 'b_checkered'},
     csau_dependencies = {
         'enableJoelContent',
     }
 }
 
-deckInfo.loc_vars = function(self, info_queue, card)
+function deckInfo.loc_vars(self, info_queue, card)
     if info_queue then
         info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.keku } }
     end
     return {vars = { self.config.hand_size } }
 end
 
-deckInfo.apply = function(self, back)
+function deckInfo.apply(self, back)
     G.E_MANAGER:add_event(Event({
         func = function()
             G.GAME.starting_params.csau_jokers_rate = G.GAME.starting_params.csau_jokers_rate or 1
             G.GAME.starting_params.csau_jokers_rate = G.GAME.starting_params.csau_jokers_rate * 2
-            for k, v in pairs(G.GAME.probabilities) do
-                G.GAME.probabilities[k] = v * 2
-            end
             return true
         end
     }))
+end
+
+function deckInfo.calculate(self, back, context)
+    if context.mod_probability then
+        return {
+            numerator = context.numerator * 2
+        }
+    end
 end
 
 return deckInfo

--- a/items/jokers/agga.lua
+++ b/items/jokers/agga.lua
@@ -25,7 +25,7 @@ function jokerInfo.calculate(self, card, context)
         context.other_card['agga_retrigger_count'..card.ID] = (context.other_card['agga_retrigger_count'..card.ID] and context.other_card['agga_retrigger_count'..card.ID] + 1) or 0
 
         if context.other_card['agga_retrigger_count'..card.ID] > 0 then
-            if card.ability.extra.x_mult > 1 and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_agga'), 1, card.ability.extra.prob) then
+            if card.ability.extra.x_mult > 1 and SMODS.pseudorandom_probability(card, pseudoseed('csau_agga'), 1, card.ability.extra.prob) then
                 if card.ability.extra.x_mult >= 3 then
                     check_for_unlock({ type = "high_agga" })
                 end

--- a/items/jokers/agga.lua
+++ b/items/jokers/agga.lua
@@ -17,7 +17,7 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.cejai } }
-    return { vars = {G.GAME.probabilities.normal, card.ability.extra.prob, card.ability.extra.x_mult_mod, card.ability.extra.x_mult } }
+    return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra.prob), card.ability.extra.x_mult_mod, card.ability.extra.x_mult } }
 end
 
 function jokerInfo.calculate(self, card, context)
@@ -25,7 +25,7 @@ function jokerInfo.calculate(self, card, context)
         context.other_card['agga_retrigger_count'..card.ID] = (context.other_card['agga_retrigger_count'..card.ID] and context.other_card['agga_retrigger_count'..card.ID] + 1) or 0
 
         if context.other_card['agga_retrigger_count'..card.ID] > 0 then
-            if card.ability.extra.x_mult > 1 and pseudorandom('agga') < G.GAME.probabilities.normal / card.ability.extra.prob then
+            if card.ability.extra.x_mult > 1 and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_agga'), 1, card.ability.extra.prob) then
                 if card.ability.extra.x_mult >= 3 then
                     check_for_unlock({ type = "high_agga" })
                 end

--- a/items/jokers/agga.lua
+++ b/items/jokers/agga.lua
@@ -17,7 +17,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.cejai } }
-    return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra.prob), card.ability.extra.x_mult_mod, card.ability.extra.x_mult } }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.prob)
+    return { vars = {num, dom, card.ability.extra.x_mult_mod, card.ability.extra.x_mult } }
 end
 
 function jokerInfo.calculate(self, card, context)

--- a/items/jokers/beginners.lua
+++ b/items/jokers/beginners.lua
@@ -1,8 +1,10 @@
 local jokerInfo = {
     name = "Beginner's Luck",
     config = {
-        prob_mult = 3,
-        disabled = false
+        extra = {
+            prob_mod = 3,
+            ante = 4
+        }
     },
     rarity = 2,
     cost = 4,
@@ -14,47 +16,27 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
-    return { vars = { } }
 end
 
 function jokerInfo.in_pool(self, args)
-    if to_big(G.GAME.round_resets.ante) <= to_big(4) then
-        return true
-    end
-end
-
-function jokerInfo.add_to_deck(self, card)
-    for k, v in pairs(G.GAME.probabilities) do
-        G.GAME.probabilities[k] = v * card.ability.prob_mult
-    end
-end
-
-function jokerInfo.remove_from_deck(self, card)
-    if not card.ability.disabled then
-        for k, v in pairs(G.GAME.probabilities) do
-            G.GAME.probabilities[k] = v / card.ability.prob_mult
-        end
-    end
+    return to_big(G.GAME.round_resets.ante) <= to_big(self.config.extra.ante)
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.end_of_round and not context.blueprint and not context.repetition and not context.individual then
-        if to_big(G.GAME.round_resets.ante) >= to_big(4) and G.GAME.blind.boss then
-            for k, v in pairs(G.GAME.probabilities) do
-                G.GAME.probabilities[k] = v / card.ability.prob_mult
-            end
-            card.ability.disabled = true
-            return {
-                message = localize('k_noluck_ex'),
-                colour = G.C.MONEY
-            }
-        end
+    if context.mod_probability and to_big(G.GAME.round_resets.ante) <= to_big(card.ability.extra.ante) then
+        return {
+            numerator = context.numerator * card.ability.extra.prob_mod
+        }
     end
 end
 
 function jokerInfo.update(self, card)
-    if card.ability.disabled and not card.debuff then
+    if to_big(G.GAME.round_resets.ante) > to_big(card.ability.extra.ante) then
+        card.ability.extra.disabled = true
         card.debuff = true
+    elseif to_big(G.GAME.round_resets.ante) <= to_big(card.ability.extra.ante) and card.ability.extra.disabled then
+        card.ability.extra.disabled = nil
+        card.debuff = false
     end
 end
 

--- a/items/jokers/bjbros.lua
+++ b/items/jokers/bjbros.lua
@@ -1,8 +1,11 @@
 local jokerInfo = {
     name = 'Blowzo Brothers',
     config = {
-        prob_1 = 4,
-        prob_2 = 4
+        extra = {
+            prob_1 = 4,
+            prob_2 = 4
+        }
+        
     },
     rarity = 2,
     cost = 5,
@@ -14,56 +17,53 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.fenix } }
-    return { vars = {G.GAME.probabilities.normal, card.ability.prob_1, card.ability.prob_2 } }
+
+    local num, dom1 = SMODS.get_probability_vars(card, 1, card.ability.extra.prob_1)
+    local _, dom2 = SMODS.get_probability_vars(card, 1, card.ability.extra.prob_2)
+    return { vars = {num, dom1, dom2 } }
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.cardarea == G.jokers and context.before and not card.debuff then
-        if context.scoring_name == "Two Pair" then
-            local bj1 = false
-            local ps1 = pseudorandom('bjbros1')
-            local ps2 = G.GAME.probabilities.normal / card.ability.prob_1
-            if ps1 < ps2 then
-                bj1 = true
-                return {
-                    card = card,
-                    level_up = true,
-                    message = localize('k_level_up_ex')
-                }
+    if not (context.cardarea == G.jokers and context.before) or card.debuff then
+        return
+    end
+
+    if context.scoring_name == "Two Pair"  then
+        local bj1 = false
+        local bj2 = false
+        if SMODS.pseudorandom_probability(card, pseudoseed('csau_bjbros1'), 1, card.ability.extra.prob_1) then
+            bj1 = true
+        end
+
+        for _, v in ipairs(context.scoring_hand) do
+            if SMODS.pseudorandom_probability(card, pseudoseed('csau_bjbros2'), 1, card.ability.extra.prob_2) then
+                if not bj2 then bj2 = true end
+
+                v:set_ability(pseudorandom_element(G.P_CENTER_POOLS.Enhanced, pseudoseed('csau_brothers_enhancement')), nil, true)
+                local juice_card = context.blueprint_card or card
+                G.E_MANAGER:add_event(Event({
+                    func = function()
+                        juice_card:juice_up()
+                        return true
+                    end
+                }))
+
+                card_eval_status_text(v, 'extra', nil, nil, nil, {
+                    message = localize('k_enhanced'),
+                })
             end
         end
-    end
-    if context.cardarea == G.jokers and context.before and not card.debuff then
-        if context.scoring_name == "Two Pair" then
-            local bj1 = false
-            local enhancements = {
-                [1] = G.P_CENTERS.m_bonus,
-                [2] = G.P_CENTERS.m_mult,
-                [3] = G.P_CENTERS.m_wild,
-                [4] = G.P_CENTERS.m_glass,
-                [5] = G.P_CENTERS.m_steel,
-                [6] = G.P_CENTERS.m_stone,
-                [7] = G.P_CENTERS.m_gold,
-                [8] = G.P_CENTERS.m_lucky,
-            }
-            for k, v in ipairs(context.scoring_hand) do
-                if pseudorandom('bjbros2') < G.GAME.probabilities.normal / card.ability.prob_2 and v.ability.effect == "Base" then
-                    if bj1 then
-                        check_for_unlock({ type = "gamer_blowzo" })
-                    end
-                    v:set_ability(enhancements[pseudorandom('hookedonthebros', 1, 8)], nil, true)
-                    G.E_MANAGER:add_event(Event({
-                        func = function()
-                            card:juice_up()
-                            v:juice_up()
-                            return {
-                                message = localize('k_enhanced'),
-                                card = context.blueprint_card or card,
-                                }
-                        end
-                    }))
-                end
+
+        if bj1 then
+            if bj2 then
+                check_for_unlock({ type = "gamer_blowzo" })
             end
+
+            return {
+                card = card,
+                level_up = true,
+                message = localize('k_level_up_ex')
+            }
         end
     end
 end

--- a/items/jokers/businesstrading.lua
+++ b/items/jokers/businesstrading.lua
@@ -4,12 +4,13 @@ local jokerInfo = {
         extra = {
             dollars = 6,
             destroy = 1,
+            chance = 3,
             destroyed = {},
         },
     },
     rarity = 1,
     cost = 6,
-    blueprint_compat = false,
+    blueprint_compat = true,
     eternal_compat = true,
     perishable_compat = true,
     streamer = "vinny",
@@ -17,11 +18,10 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.keku } }
-    return { vars = {card.ability.extra.dollars, G.GAME.probabilities.normal, card.ability.extra.destroy} }
+    return { vars = {card.ability.extra.dollars, SMODS.get_probability_vars(card, 1, card.ability.extra.chance), card.ability.extra.destroy} }
 end
 
 local function all_faces(hand)
-    local allfaces = true
     for k, v in ipairs(hand) do
         if not v:is_face() then
             return false
@@ -31,25 +31,41 @@ local function all_faces(hand)
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.before and context.cardarea == G.jokers and not context.blueprint and to_big(G.GAME.current_round.hands_played) == to_big(0) then
-        if all_faces(context.full_hand) then
-            ease_dollars(to_big(card.ability.extra.dollars))
-            card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('$') .. to_big(card.ability.extra.dollars), colour = G.C.MONEY})
+    if card.debuff then return end
+
+    if context.before and context.cardarea == G.jokers and to_big(G.GAME.current_round.hands_played) == to_big(0) and all_faces(context.full_hand) then
+        card.ability.csau_business_activated = {}
+        if SMODS.pseudorandom_probability(card, pseudoseed('csau_business_1'), 1, card.ability.extra.chance) then
+            local idx_tbl = {}
+            for i=1, #context.full_hand do
+                idx_tbl[#idx_tbl+1] = i
+            end
+
+            while #idx_tbl > 1 and #idx_tbl > card.ability.extra.destroy do
+                table.remove(idx_tbl, pseudorandom(pseudoseed('csau_business_2'), 1, #idx_tbl))
+            end
+
+            for _, v in pairs(idx_tbl) do
+                card.ability.csau_business_activated[context.full_hand[v]] = true
+            end
         end
+
+        
+        return {
+            dollars = card.ability.extra.dollars
+        }
     end
-    local bad_context = context.repetition or context.blueprint or context.individual or context.retrigger_joker
-    if context.final_scoring_step and not bad_context then
-        if all_faces(context.full_hand) and pseudorandom('businesstrading') < G.GAME.probabilities.normal / 3 then
-            card.ability.extra.destroyed = context.full_hand[pseudorandom('businesstrading_1', 1, #context.full_hand)]
-        end
+
+    if context.blueprint then return end
+
+    if context.destroy_card and card.ability.csau_business_activated[context.destroy_card] then
+        return {
+            remove = true
+        }
     end
-    if context.destroying_card and table.contains(context.full_hand, context.destroy_card) and not bad_context then
-        if context.destroy_card == card.ability.extra.destroyed then
-            return true
-        end
-    end
-    if context.end_of_round then
-        card.ability.extra.destroyed = nil
+
+    if context.end_of_round and not context.individual and not context.repetition then
+        card.ability.csau_business_activated = nil
     end
 end
 

--- a/items/jokers/businesstrading.lua
+++ b/items/jokers/businesstrading.lua
@@ -18,7 +18,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.keku } }
-    return { vars = {card.ability.extra.dollars, SMODS.get_probability_vars(card, 1, card.ability.extra.chance), card.ability.extra.destroy} }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.chance)
+    return { vars = {card.ability.extra.dollars, num, dom, card.ability.extra.destroy} }
 end
 
 local function all_faces(hand)

--- a/items/jokers/depressedbrother.lua
+++ b/items/jokers/depressedbrother.lua
@@ -17,22 +17,22 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
 	info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.cejai } }
-	return { vars = {G.GAME.probabilities.normal, card.ability.extra.prob, card.ability.extra.mult_mod } }
+	return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra.prob), card.ability.extra.mult_mod } }
 end
 
 function jokerInfo.calculate(self, card, context)
-	local bad_context = context.repetition or context.individual or context.blueprint
-	if context.cardarea == G.jokers and context.before and not card.debuff and not bad_context then
-		local proc = false
-		for i, v in ipairs(context.full_hand) do
-			if not table.contains(context.scoring_hand, v) then
-				if pseudorandom('soak') < G.GAME.probabilities.normal / card.ability.extra.prob then
-					proc = true
-					v.ability.perma_mult = v.ability.perma_mult or 0
-					v.ability.perma_mult = v.ability.perma_mult + card.ability.extra.mult_mod
-					card_eval_status_text(v, 'extra', nil, nil, nil, {message = localize('k_upgrade_ex'), colour = G.C.MULT, func = function() card:juice_up() end})
+	if card.debuff or not context.bfore then return end
+
+	for _, v in ipairs(context.full_hand) do
+		if not SMODS.in_scoring(v, context.scoring_hand) and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_depressed'), 1, card.ability.extra.prob) then
+			v.ability.perma_mult = (v.ability.perma_mult or 0) + card.ability.extra.mult_mod
+			card_eval_status_text(v, 'extra', nil, nil, nil, {
+				message = localize('k_upgrade_ex'),
+				colour = G.C.MULT,
+				func = function() 
+					card:juice_up()
 				end
-			end
+			})
 		end
 	end
 end

--- a/items/jokers/depressedbrother.lua
+++ b/items/jokers/depressedbrother.lua
@@ -24,7 +24,7 @@ function jokerInfo.calculate(self, card, context)
 	if card.debuff or not context.bfore then return end
 
 	for _, v in ipairs(context.full_hand) do
-		if not SMODS.in_scoring(v, context.scoring_hand) and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_depressed'), 1, card.ability.extra.prob) then
+		if not SMODS.in_scoring(v, context.scoring_hand) and SMODS.pseudorandom_probability(card, pseudoseed('csau_depressed'), 1, card.ability.extra.prob) then
 			v.ability.perma_mult = (v.ability.perma_mult or 0) + card.ability.extra.mult_mod
 			card_eval_status_text(v, 'extra', nil, nil, nil, {
 				message = localize('k_upgrade_ex'),

--- a/items/jokers/depressedbrother.lua
+++ b/items/jokers/depressedbrother.lua
@@ -17,7 +17,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
 	info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.cejai } }
-	return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra.prob), card.ability.extra.mult_mod } }
+	local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.prob)
+	return { vars = {num, dom, card.ability.extra.mult_mod } }
 end
 
 function jokerInfo.calculate(self, card, context)

--- a/items/jokers/emmanuel.lua
+++ b/items/jokers/emmanuel.lua
@@ -14,12 +14,12 @@ local jokerInfo = {
 function jokerInfo.loc_vars(self, info_queue, card)
 	info_queue[#info_queue+1] = G.P_TAGS.tag_negative
 	info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gappie } }
-	return { vars = {G.GAME.probabilities.normal, card.ability.extra} }
+	return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra)} }
 end
 
 function jokerInfo.calculate(self, card, context)
 	if context.end_of_round and not card.debuff and not context.individual and not context.repetition then
-		if pseudorandom('blast') < G.GAME.probabilities.normal / card.ability.extra then
+		if SMODS.pseudorandom_probability(card, pseudoseed('csau_blast'), 1, card.ability.extra) then
 			check_for_unlock({ type = "activate_eman" })
 			card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_plus_negative'), colour = HEX('39484e')})
 			G.E_MANAGER:add_event(Event({

--- a/items/jokers/fate.lua
+++ b/items/jokers/fate.lua
@@ -14,36 +14,7 @@ function jokerInfo.loc_vars(self, info_queue, card)
     return { vars = { } }
 end
 
-local function starts_with(str, start)
-    return string.sub(str, 1, #start) == start
-end
 
-local tag_colors = {
-    tag_uncommon = G.C.GREEN,
-    tag_rare = G.C.RED,
-    tag_negative = G.C.DARK_EDITION,
-    tag_foil = G.C.DARK_EDITION,
-    tag_holo = G.C.DARK_EDITION,
-    tag_polychrome = G.C.DARK_EDITION,
-    tag_investment = G.C.MONEY,
-    tag_voucher = G.C.SECONDARY_SET.Voucher,
-    tag_boss = G.C.IMPORTANT,
-    tag_standard = G.C.IMPORTANT,
-    tag_charm = G.C.SECONDARY_SET.Tarot,
-    tag_meteor = G.C.SECONDARY_SET.Planet,
-    tag_buffoon = G.C.RED,
-    tag_handy = G.C.MONEY,
-    tag_garbage = G.C.MONEY,
-    tag_ethereal = G.C.SECONDARY_SET.Spectral,
-    tag_coupon = G.C.MONEY,
-    tag_double = G.C.IMPORTANT,
-    tag_juggle = G.C.BLUE,
-    tag_d_six = G.C.GREEN,
-    tag_top_up = G.C.BLUE,
-    tag_skip = G.C.MONEY,
-    tag_orbital = G.C.SECONDARY_SET.Planet,
-    tag_economy = G.C.MONEY,
-}
 
 function jokerInfo.calculate(self, card, context)
     if context.end_of_round and not card.debuff and not context.individual and not context.repetition then
@@ -52,7 +23,7 @@ function jokerInfo.calculate(self, card, context)
             check_for_unlock({ type = "activate_watto" })
         end
         if roll == 1 then
-            local key, free_tag, color = G.FUNCS.csau_get_free_tag('joker', 'IMAWATTOOO')
+            local key, color = G.FUNCS.csau_get_tag('joker', 'IMAWATTOOO')
             card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_plus_one')..G.localization.descriptions["Tag"][key].name, colour = color})
             G.E_MANAGER:add_event(Event({
                 trigger = 'before',
@@ -65,7 +36,7 @@ function jokerInfo.calculate(self, card, context)
                 end)
             }))
         elseif roll == 2 then
-            local key, free_tag, color = G.FUNCS.csau_get_free_tag('booster', 'ANNIEAREYOUOKAY')
+            local key, color = G.FUNCS.csau_get_tag('booster', 'ANNIEAREYOUOKAY')
             card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_plus_one')..G.localization.descriptions["Tag"][key].name, colour = color})
             G.E_MANAGER:add_event(Event({
                 trigger = 'before',
@@ -78,7 +49,7 @@ function jokerInfo.calculate(self, card, context)
                 end)
             }))
         elseif roll == 3 then
-            local key, free_tag, color = G.FUNCS.csau_get_free_tag('any', 'ISITALRIGHTTOBEMYSELFAGAIN')
+            local key, color = G.FUNCS.csau_get_tag('any', 'ISITALRIGHTTOBEMYSELFAGAIN')
             card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_plus_two')..G.localization.descriptions["Tag"][key].name, colour = color})
             for i=1, 2 do
                 G.E_MANAGER:add_event(Event({

--- a/items/jokers/flusher.lua
+++ b/items/jokers/flusher.lua
@@ -18,32 +18,38 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
-    return { vars = {G.FUNCS.csau_add_chance(card.ability.extra.prob_extra, {multiply = true, start_at_one = true}), card.ability.extra.prob, card.ability.extra.prob_mod} }
+    return { 
+        vars = {
+            SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob),
+            card.ability.extra.prob_mod
+        } 
+    }
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.cardarea == G.jokers and context.before and not self.debuff then
-        if context.scoring_name == "Flush" then
-            if pseudorandom('flusher') < G.FUNCS.csau_add_chance(card.ability.extra.prob_extra, {multiply = true, start_at_one = true}) / card.ability.extra.prob then
-                return {
-                    card = card,
-                    level_up = true,
-                    message = localize('k_level_up_ex')
-                }
-            end
-        end
+    if card.debuff then return end
+
+    if context.cardarea == G.jokers and context.before and context.scoring_name == "Flush"
+    and SMODS.pseudorandom_probability(card, pseudoseed('csau_flusher'), card.ability.extra.prob_extra, card.ability.extra.prob) then
+        return {
+            card = card,
+            level_up = true,
+            message = localize('k_level_up_ex')
+        }
     end
-    if context.selling_card and not context.blueprint then
-        if context.card.config.center.consumeable then
-            card.ability.extra.prob_extra = card.ability.extra.prob_extra + 1
-            return {
-                card = card,
-                message = localize{type = 'variable', key = 'a_chance', vars = {1+card.ability.extra.prob_extra, card.ability.extra.prob}},
-                colour = G.C.GREEN
-            }
-        end
+
+    if context.blueprint then return end
+
+    if context.selling_card and context.card.config.center.consumeable then
+        card.ability.extra.prob_extra = card.ability.extra.prob_extra + 1
+        return {
+            card = card,
+            message = localize{type = 'variable', key = 'a_chance', vars = {SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob)}},
+            colour = G.C.GREEN
+        }
     end
-    if context.end_of_round and not context.blueprint and to_big(card.ability.extra.prob_extra) > to_big(0) then
+
+    if context.end_of_round and to_big(card.ability.extra.prob_extra) > to_big(0) then
         card.ability.extra.prob_extra = 0
         return {
             message = localize('k_reset'),

--- a/items/jokers/flusher.lua
+++ b/items/jokers/flusher.lua
@@ -18,12 +18,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
-    return { 
-        vars = {
-            SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob),
-            card.ability.extra.prob_mod
-        } 
-    }
+    local num, dom = SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob)
+    return { vars = {num, dom, card.ability.extra.prob_mod } }
 end
 
 function jokerInfo.calculate(self, card, context)

--- a/items/jokers/grand.lua
+++ b/items/jokers/grand.lua
@@ -20,7 +20,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.akai } }
-    return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra.chance), card.ability.extra.x_mult, card.ability.extra.cardid} }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.chance)
+    return { vars = {num, dom, card.ability.extra.x_mult, card.ability.extra.cardid} }
 end
 
 function jokerInfo.calculate(self, card, context)

--- a/items/jokers/grand.lua
+++ b/items/jokers/grand.lua
@@ -1,9 +1,9 @@
 local jokerInfo = {
     name = "7 Funny Story",
     config = {
-        rate = 7,
-        cardid = 7,
         extra = {
+            chance = 7,
+            cardid = 7,
             x_mult = 7,
         }
     },
@@ -20,24 +20,26 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.akai } }
-    return { vars = {G.GAME.probabilities.normal, card.ability.rate, card.ability.extra.x_mult, card.ability.cardid} }
+    return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra.chance), card.ability.extra.x_mult, card.ability.extra.cardid} }
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.cardarea == G.jokers and not context.before and context.joker_main and not context.repetition then
+    if card.debuff then return end
+
+    if context.cardarea == G.jokers and context.joker_main then
         local trigger = false
-        for k, v in ipairs(context.full_hand) do
+        for _, v in ipairs(context.full_hand) do
             if v:get_id() == 7 then
                 trigger = true
+                break;
             end
         end
-        if trigger then
-            if pseudorandom('fleentstones') < G.GAME.probabilities.normal / card.ability.rate then
-                return {
-                    message = localize{type='variable',key='a_xmult',vars={to_big(card.ability.extra.x_mult)}},
-                    Xmult_mod = card.ability.extra.x_mult,
-                }
-            end
+
+        if trigger and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_grand'), 1, card.ability.extra.chance) then
+            return {
+                message = localize{type='variable',key='a_xmult',vars={to_big(card.ability.extra.x_mult)}},
+                Xmult_mod = card.ability.extra.x_mult,
+            }
         end
     end
 end

--- a/items/jokers/grand.lua
+++ b/items/jokers/grand.lua
@@ -35,7 +35,7 @@ function jokerInfo.calculate(self, card, context)
             end
         end
 
-        if trigger and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_grand'), 1, card.ability.extra.chance) then
+        if trigger and SMODS.pseudorandom_probability(card, pseudoseed('csau_grand'), 1, card.ability.extra.chance) then
             return {
                 message = localize{type='variable',key='a_xmult',vars={to_big(card.ability.extra.x_mult)}},
                 Xmult_mod = card.ability.extra.x_mult,

--- a/items/jokers/itsafeature.lua
+++ b/items/jokers/itsafeature.lua
@@ -19,7 +19,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.burlap } }
-    return { vars = { card.ability.extra.money_mod, SMODS.get_probability_vars(card, 1, card.ability.extra.prob), card.ability.extra.money, } }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.prob)
+    return { vars = { card.ability.extra.money_mod, num, dom, card.ability.extra.money } }
 end
 
 function jokerInfo.calculate(self, card, context)
@@ -27,7 +28,7 @@ function jokerInfo.calculate(self, card, context)
 
     if context.before and not context.blueprint then
         card.ability.extra.money = card.ability.extra.money + card.ability.extra.money_mod
-        if to_big(card.ability.extra.money) >= to_big(card.abiltiy.extra.ach_dollars) then
+        if to_big(card.ability.extra.money) >= to_big(card.ability.extra.ach_dollars) then
             check_for_unlock({ type = "high_feature" })
         end
 

--- a/items/jokers/junka.lua
+++ b/items/jokers/junka.lua
@@ -30,14 +30,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.yunkie } }
-    return { 
-        vars = {
-            card.ability.extra.x_mult_mod,
-            card.ability.extra.prob_mod,
-            SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob),
-            card.ability.extra.x_mult
-        }
-    }
+    local num, dom = SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob)
+    return { vars = {card.ability.extra.x_mult_mod, card.ability.extra.prob_mod, num, dom, card.ability.extra.x_mult } }
 end
 
 function jokerInfo.locked_loc_vars(self, info_queue, card)

--- a/items/jokers/junka.lua
+++ b/items/jokers/junka.lua
@@ -30,7 +30,14 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.yunkie } }
-    return { vars = { card.ability.extra.x_mult_mod, card.ability.extra.prob_mod, G.FUNCS.csau_add_chance(card.ability.extra.prob_extra, {multiply = true}), card.ability.extra.prob, card.ability.extra.x_mult } }
+    return { 
+        vars = {
+            card.ability.extra.x_mult_mod,
+            card.ability.extra.prob_mod,
+            SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob),
+            card.ability.extra.x_mult
+        }
+    }
 end
 
 function jokerInfo.locked_loc_vars(self, info_queue, card)
@@ -46,8 +53,10 @@ function jokerInfo.check_for_unlock(self, args)
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.vhs_death and not context.blueprint then
-        if not card.ability.extra.destroyed and pseudorandom('junka') < G.FUNCS.csau_add_chance(card.ability.extra.prob_extra, {multiply = true}) / card.ability.extra.prob then
+    if card.debuff then return end
+
+    if context.vhs_death and not context.blueprint and not card.ability.extra.destroyed then
+        if SMODS.pseudorandom_probability(card, pseudoseed('csau_junka'), card.ability.extra.prob_extra, card.ability.extra.prob) then
             card.ability.extra.destroyed = true
             G.E_MANAGER:add_event(Event({
                 func = function()
@@ -74,13 +83,11 @@ function jokerInfo.calculate(self, card, context)
             card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_xmult', vars = {card.ability.extra.x_mult}}, delay = 0.4 })
         end
     end
-    if context.joker_main and context.cardarea == G.jokers then
-        if to_big(card.ability.extra.x_mult) > to_big(1) then
-            return {
-                message = localize{type='variable',key='a_xmult',vars={card.ability.extra.x_mult}},
-                Xmult_mod = card.ability.extra.x_mult,
-            }
-        end
+
+    if context.joker_main and to_big(card.ability.extra.x_mult) > to_big(1) then
+        return {
+            x_mult = card.ability.extra.x_mult,
+        }
     end
 end
 

--- a/items/jokers/meteor.lua
+++ b/items/jokers/meteor.lua
@@ -1,9 +1,8 @@
 local jokerInfo = {
     name = "Meteor",
     config = {
-        id = 7,
         extra = {
-            x_mult = 2
+            id = 7,
         }
     },
     rarity = 1,
@@ -27,21 +26,22 @@ function jokerInfo.check_for_unlock(self, args)
 end
 
 function jokerInfo.calculate(self, card, context)
-    local bad_context = context.repetition or context.blueprint
-    if context.individual and context.cardarea == G.play and not card.debuff and not bad_context then
-        if context.other_card:get_id() == 7 and context.other_card.ability.effect ~= "Glass Card" then
-            return {
-                x_mult = (next(SMODS.find_card("j_csau_plaguewalker")) and 3 or card.ability.extra.x_mult),
-                card = context.other_card
-            }
-        end
+    if context.check_enhancement and context.other_card:get_id() == card.ability.extra.id and not context.other_card.config.center.key == 'm_glass' then
+        return {
+            ['m_glass'] = true
+        }
     end
-    bad_context = context.repetition or context.blueprint or context.individual
-    if context.destroying_card and not bad_context then
-        if context.destroying_card:get_id() == 7 and context.destroying_card.ability.effect ~= "Glass Card" then
-            if pseudorandom('meteor') < G.GAME.probabilities.normal / (next(SMODS.find_card("j_csau_plaguewalker")) and 2 or 4) then
-                return true
+
+    if context.remove_playing_cards then
+        local tally = 0
+        for _, v in ipairs(context.removed) do
+            if v:get_id() == card.ability.extra.id and not v.config.center.key == 'm_glass' then
+                tally = tally + 1
             end
+        end
+        
+        if tally > 0 then
+            check_for_unlock({type = 'destroy_meteor'})
         end
     end
 end

--- a/items/jokers/monkey.lua
+++ b/items/jokers/monkey.lua
@@ -17,7 +17,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.lyzerus } }
-    return { vars = { card.ability.extra.mult, SMODS.get_probability_vars(card, 1, card.ability.extra.prob) } }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.prob)
+    return { vars = { card.ability.extra.mult, num, dom } }
 end
 
 function jokerInfo.check_for_unlock(self, args)

--- a/items/jokers/monkey.lua
+++ b/items/jokers/monkey.lua
@@ -17,7 +17,7 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.lyzerus } }
-    return { vars = { card.ability.extra.mult, G.GAME.probabilities.normal, card.ability.extra.prob } }
+    return { vars = { card.ability.extra.mult, SMODS.get_probability_vars(card, 1, card.ability.extra.prob) } }
 end
 
 function jokerInfo.check_for_unlock(self, args)
@@ -27,20 +27,19 @@ function jokerInfo.check_for_unlock(self, args)
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.individual and context.cardarea == G.play and not card.debuff then
+    if card.debuff then return end
+
+    if context.individual and context.cardarea == G.play then
         return {
             mult = card.ability.extra.mult,
-            card = card
+            card = context.blueprint_card or card
         }
     end
-    if context.destroying_card and not context.blueprint then
-        if pseudorandom('monkeymode') < G.GAME.probabilities.normal / card.ability.extra.prob then
-            G.E_MANAGER:add_event(Event({trigger = 'after', func = function()
-                play_sound('whoosh2', math.random()*0.2 + 0.9,0.5)
-                play_sound('crumple'..math.random(1, 5), math.random()*0.2 + 0.9,0.5)
-                return true end }))
-            return true
-        end
+
+    if context.destroy_card and not context.blueprint and SMODS.pseudorandom_probability(card, pseudoseed('csau_monkey'), 1, card.ability.extra.prob) then
+        return {
+            remove = true
+        }
     end
 end
 

--- a/items/jokers/pivot.lua
+++ b/items/jokers/pivot.lua
@@ -1,6 +1,10 @@
 local jokerInfo = {
 	name = 'Pivyot Joker',
-	config = {},
+	config = {
+		extra = {
+			chance = 3
+		}
+	},
 	rarity = 1,
 	cost = 5,
 	blueprint_compat = true,
@@ -13,24 +17,21 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
 	info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
-	return { vars = {G.GAME.probabilities.normal} }
+	return { vars = {SMODS.get_probability_vars(card, 1, card.ability.extra.chance)} }
 end
 
 function jokerInfo.calculate(self, card, context)
-	if context.cardarea == G.jokers and context.before and not self.debuff then
-		if context.scoring_name == "High Card" then
-			if pseudorandom('pivot') < G.GAME.probabilities.normal / 3 then
-				return {
-					card = card,
-					level_up = true,
-					message = localize('k_level_up_ex')
-				}
-			end
-		end
+	if card.debuff then return end
+
+	if context.cardarea == G.jokers and context.before and context.scoring_name == "High Card"
+	and	SMODS.pseudorandom_probability(card, pseudoseed('csau_pivyot'), 1, card.ability.extra.chance) then
+		return {
+			card = card,
+			level_up = true,
+			message = localize('k_level_up_ex')
+		}
 	end
 end
-
-
 
 return jokerInfo
 	

--- a/items/jokers/plaguewalker.lua
+++ b/items/jokers/plaguewalker.lua
@@ -1,7 +1,12 @@
 local jokerInfo = {
     name = 'Plaguewalker',
     config = {
-        debuff = false,
+        extra = {
+            glass_mult = 3,
+            glass_break = 2,
+            old_glass_mult = 2,
+            old_glass_break = 4,
+        }
     },
     rarity = 2,
     cost = 6,
@@ -12,99 +17,54 @@ local jokerInfo = {
     origin = 'monkeywrench'
 }
 
-local plaguewalker_active = function(card)
-    card = card or nil
-    local plaguewalkers = SMODS.find_card("j_csau_plaguewalker")
-    for i, v in ipairs(plaguewalkers) do
-        if (card and v ~= card) or not card then
-            if not v.debuff then
-                return true
-            end
-        end
-    end
-    return false
-end
-
-local gcxm_ref = Card.get_chip_x_mult
-function Card:get_chip_x_mult(context)
-    local ref = gcxm_ref(self, context)
-    if self.ability.name == "Glass Card" and next(SMODS.find_card("j_csau_plaguewalker")) then
-        return 3
-    else
-        return ref
-    end
-end
-
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_glass
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.zeurel } }
-    return { vars = { G.GAME.probabilities.normal } }
-end
-
-local function activate(bool)
-    if bool then
-        G.P_CENTERS.m_glass.config.extra = 2
-        G.P_CENTERS.m_glass.config.Xmult = 3
-        for _, area in ipairs(SMODS.get_card_areas('playing_cards')) do
-            for _, _card in ipairs(area.cards) do
-                if SMODS.has_enhancement(_card, 'm_glass') then
-                    _card.ability.extra = 2
-                    _card.ability.Xmult = 3
-                end
-            end
-        end
-    else
-        G.P_CENTERS.m_glass.config.extra = 4
-        G.P_CENTERS.m_glass.config.Xmult = 2
-        for _, area in ipairs(SMODS.get_card_areas('playing_cards')) do
-            for _, _card in ipairs(area.cards) do
-                if SMODS.has_enhancement(_card, 'm_glass') then
-                    _card.ability.extra = 4
-                    _card.ability.Xmult = 2
-                end
-            end
-        end
-    end
+    return { vars = { card.ability.extra.glass_mult, SMODS.get_probability_vars(card, 1, card.ability.extra.glass_break) } }
 end
 
 function jokerInfo.in_pool(self, args)
     for _, v in ipairs(G.playing_cards) do
-        if v.ability.effect == "Glass Card" then
+        if v.config.center.key == 'm_glass' then
             return true
         end
     end
 end
 
-function jokerInfo.load(self, card)
-    activate(true)
-end
-
-function jokerInfo.add_to_deck(self, card)
-    activate(true)
-end
-
-function jokerInfo.remove_from_deck(self, card)
-    local deactivate = true
-    local pw = SMODS.find_card("j_csau_plaguewalker")
-    for i, v in ipairs(pw) do
-        if v ~= card then
-            deactivate = false
+function jokerInfo.add_to_deck(self, card, from_debuff)
+    local plagues = SMODS.find_card('j_csau_plaguewalker')
+    local other_plague = false
+    for _, v in ipairs(plagues) do
+        if v ~= card and not v.debuff then
+            other_plague = true
+            break
         end
     end
-    if deactivate then
-        activate(false)
+
+    if other_plague then return end
+
+    G.P_CENTERS.m_glass.config.Xmult = card.ability.extra.glass_mult
+    G.P_CENTERS.m_glass.config.extra = card.ability.extra.glass_break
+
+    for _, v in pairs(G.I.CARD) do
+        if v.config and v.config.center and v.config.center.key == 'm_glass' then
+            v.ability.extra = G.P_CENTERS.m_glass.config.extra
+            v.ability.x_mult = G.P_CENTERS.m_glass.config.Xmult
+        end
     end
 end
 
-function jokerInfo.update(self, card)
-    if card.debuff and not card.ability.debuff then
-        card.ability.debuff = true
-        if not plaguewalker_active(card) then
-            activate(false)
+function jokerInfo.remove_from_deck(self, card, from_debuff)
+    if next(SMODS.find_card('j_csau_plaguewalker')) then return end
+
+    G.P_CENTERS.m_glass.config.Xmult = card.ability.extra.old_glass_mult
+    G.P_CENTERS.m_glass.config.extra = card.ability.extra.old_glass_break
+
+    for _, v in pairs(G.I.CARD) do
+        if v.config and v.config.center and v.config.center.key == 'm_glass' then
+            v.ability.extra = G.P_CENTERS.m_glass.config.extra
+            v.ability.x_mult = G.P_CENTERS.m_glass.config.Xmult
         end
-    elseif not card.debuff and card.ability.debuff then
-        card.ability.debuff = false
-        activate(true)
     end
 end
 

--- a/items/jokers/plaguewalker.lua
+++ b/items/jokers/plaguewalker.lua
@@ -17,6 +17,30 @@ local jokerInfo = {
     origin = 'monkeywrench'
 }
 
+local function apply_plague(card, x_mult, break_chance)
+    local plagues = SMODS.find_card('j_csau_plaguewalker')
+    local other_plague = false
+    for _, v in ipairs(plagues) do
+        if v ~= card and not v.debuff then
+            other_plague = true
+            break
+        end
+    end
+
+    if other_plague then return end
+
+    G.P_CENTERS.m_glass.config.Xmult = x_mult
+    G.P_CENTERS.m_glass.config.extra = break_chance
+
+    for _, v in pairs(G.I.CARD) do
+        if v.config and v.config.center and v.config.center.key == 'm_glass' then
+            v.ability.extra = break_chance
+            v.ability.x_mult = x_mult
+            v.ability.Xmult = x_mult
+        end
+    end
+end
+
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_glass
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.zeurel } }
@@ -32,40 +56,15 @@ function jokerInfo.in_pool(self, args)
 end
 
 function jokerInfo.add_to_deck(self, card, from_debuff)
-    local plagues = SMODS.find_card('j_csau_plaguewalker')
-    local other_plague = false
-    for _, v in ipairs(plagues) do
-        if v ~= card and not v.debuff then
-            other_plague = true
-            break
-        end
-    end
+    apply_plague(card, card.ability.extra.glass_mult, card.ability.extra.glass_break)
+end
 
-    if other_plague then return end
-
-    G.P_CENTERS.m_glass.config.Xmult = card.ability.extra.glass_mult
-    G.P_CENTERS.m_glass.config.extra = card.ability.extra.glass_break
-
-    for _, v in pairs(G.I.CARD) do
-        if v.config and v.config.center and v.config.center.key == 'm_glass' then
-            v.ability.extra = G.P_CENTERS.m_glass.config.extra
-            v.ability.x_mult = G.P_CENTERS.m_glass.config.Xmult
-        end
-    end
+function jokerInfo.load(self, card, cardTable, other_card)
+    apply_plague(card, card.ability.extra.glass_mult, card.ability.extra.glass_break)
 end
 
 function jokerInfo.remove_from_deck(self, card, from_debuff)
-    if next(SMODS.find_card('j_csau_plaguewalker')) then return end
-
-    G.P_CENTERS.m_glass.config.Xmult = card.ability.extra.old_glass_mult
-    G.P_CENTERS.m_glass.config.extra = card.ability.extra.old_glass_break
-
-    for _, v in pairs(G.I.CARD) do
-        if v.config and v.config.center and v.config.center.key == 'm_glass' then
-            v.ability.extra = G.P_CENTERS.m_glass.config.extra
-            v.ability.x_mult = G.P_CENTERS.m_glass.config.Xmult
-        end
-    end
+    apply_plague(card, card.ability.extra.old_glass_mult, card.ability.extra.old_glass_break)
 end
 
 return jokerInfo

--- a/items/jokers/plaguewalker.lua
+++ b/items/jokers/plaguewalker.lua
@@ -44,7 +44,8 @@ end
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_glass
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.zeurel } }
-    return { vars = { card.ability.extra.glass_mult, SMODS.get_probability_vars(card, 1, card.ability.extra.glass_break) } }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.glass_break)
+    return { vars = { card.ability.extra.glass_mult, num, dom } }
 end
 
 function jokerInfo.in_pool(self, args)

--- a/items/jokers/powers.lua
+++ b/items/jokers/powers.lua
@@ -12,19 +12,6 @@ local jokerInfo = {
     streamer = "joel",
 }
 
-G.FUNCS.powers_active = function(card)
-    card = card or nil
-    local powers = SMODS.find_card("j_csau_powers")
-    for i, v in ipairs(powers) do
-        if (card and v ~= card) or not card then
-            if not v.debuff then
-                return true
-            end
-        end
-    end
-    return false
-end
-
 function jokerInfo.check_for_unlock(self, args)
     if args.type == "wheel_nope" then
         return true
@@ -42,34 +29,11 @@ function jokerInfo.calculate(self, card, context)
             xmult = card.ability.extra,
         }
     end
-end
 
-local function activate(bool)
-    if bool then
-        G.GAME.probabilities.csau_backup = G.GAME.probabilities.normal
-        G.GAME.probabilities.normal = 0
-    else
-        G.GAME.probabilities.normal = G.GAME.probabilities.csau_backup
-    end
-end
-
-function jokerInfo.add_to_deck(self, card)
-    activate(true)
-end
-
-function jokerInfo.remove_from_deck(self, card)
-    activate(false)
-end
-
-function jokerInfo.update(self, card)
-    if card.debuff and not card.ability.debuff then
-        card.ability.debuff = true
-        if not G.FUNCS.powers_active(card) then
-            activate(false)
-        end
-    elseif not card.debuff and card.ability.debuff then
-        card.ability.debuff = false
-        activate(true)
+    if context.fix_probability then
+        return {
+            numerator = 0
+        }
     end
 end
 

--- a/items/jokers/protogent.lua
+++ b/items/jokers/protogent.lua
@@ -17,54 +17,57 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.rerun } }
-    return { vars = { G.GAME.probabilities.normal, card.ability.extra.boss_prob, card.ability.extra.save_prob } }
+    local num, dom1 = SMODS.get_probability_vars(card, 1, card.ability.extra.boss_prob)
+    local _, dom2 = SMODS.get_probability_vars(card, 1, card.ability.extra.save_prob)
+    return { vars = { num, dom1, dom2 } }
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.setting_blind and context.blind.boss and not card.getting_sliced then
-        if pseudorandom('malwarespywaretrojan') < G.GAME.probabilities.normal / card.ability.extra.boss_prob then
-            G.E_MANAGER:add_event(Event({
-                func = function()
-                    G.GAME.blind:disable()
-                    play_sound('timpani')
-                    card.T.r = -0.2
-                    card:juice_up(0.3, 0.4)
-                    card.states.drag.is = true
-                    card.children.center.pinch.x = true
-                    G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                         func = function()
-                             G.jokers:remove_card(card)
-                             card:remove()
-                             card = nil
-                             return true
-                         end
-                    }))
-                    return true
-                end
-            }))
-            return {
-                message = localize('ph_boss_disabled'),
-                colour = G.C.FILTER
-            }
-        end
+    if card.debuff or context.blueprint then return end
+
+    if context.setting_blind and G.GAME.blind:get_type() == 'Boss' and not card.getting_sliced
+    and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_proto_boss'), 1, card.ability.extra.boss_prob) then
+        G.E_MANAGER:add_event(Event({
+            func = function()
+                G.GAME.blind:disable()
+                play_sound('timpani')
+                card.T.r = -0.2
+                card:juice_up(0.3, 0.4)
+                card.states.drag.is = true
+                card.children.center.pinch.x = true
+                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
+                        func = function()
+                            G.jokers:remove_card(card)
+                            card:remove()
+                            card = nil
+                            return true
+                        end
+                }))
+                return true
+            end
+        }))
+        return {
+            message = localize('ph_boss_disabled'),
+            colour = G.C.FILTER
+        }
     end
-    if not context.blueprint_card and context.game_over then
-        if pseudorandom('allgoneforever') < G.GAME.probabilities.normal / card.ability.extra.save_prob then
-            G.E_MANAGER:add_event(Event({
-                func = function()
-                    G.hand_text_area.blind_chips:juice_up()
-                    G.hand_text_area.game_chips:juice_up()
-                    play_sound('tarot1')
-                    card:start_dissolve()
-                    return true
-                end
-            }))
-            check_for_unlock({ type = "activate_proto" })
-            return {
-                saved = 'ph_saved_proto',
-                colour = G.C.RED
-            }
-        end
+
+    if context.game_over and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_proto_save'), 1, card.ability.extra.save_prob) then
+        G.E_MANAGER:add_event(Event({
+            func = function()
+                G.hand_text_area.blind_chips:juice_up()
+                G.hand_text_area.game_chips:juice_up()
+                play_sound('tarot1')
+                card:start_dissolve()
+                return true
+            end
+        }))
+        
+        check_for_unlock({ type = "activate_proto" })
+        return {
+            saved = 'ph_saved_proto',
+            colour = G.C.RED
+        }
     end
 end
 

--- a/items/jokers/protogent.lua
+++ b/items/jokers/protogent.lua
@@ -26,7 +26,7 @@ function jokerInfo.calculate(self, card, context)
     if card.debuff or context.blueprint then return end
 
     if context.setting_blind and G.GAME.blind:get_type() == 'Boss' and not card.getting_sliced
-    and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_proto_boss'), 1, card.ability.extra.boss_prob) then
+    and SMODS.pseudorandom_probability(card, pseudoseed('csau_proto_boss'), 1, card.ability.extra.boss_prob) then
         G.E_MANAGER:add_event(Event({
             func = function()
                 G.GAME.blind:disable()
@@ -52,7 +52,7 @@ function jokerInfo.calculate(self, card, context)
         }
     end
 
-    if context.game_over and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_proto_save'), 1, card.ability.extra.save_prob) then
+    if context.game_over and SMODS.pseudorandom_probability(card, pseudoseed('csau_proto_save'), 1, card.ability.extra.save_prob) then
         G.E_MANAGER:add_event(Event({
             func = function()
                 G.hand_text_area.blind_chips:juice_up()

--- a/items/jokers/quarterdumb.lua
+++ b/items/jokers/quarterdumb.lua
@@ -1,6 +1,10 @@
 local jokerInfo = {
 	name = 'Quarterdumb',
-	config = {},
+	config = {
+		extra = {
+			hand_mod = 1
+		}
+	},
 	rarity = 4,
 	cost = 20,
 	unlocked = false,
@@ -14,31 +18,23 @@ local jokerInfo = {
 }
 
 function jokerInfo.loc_vars(self, info_queue, card)
-	return { vars = {G.GAME.probabilities.normal} }
+	return { vars = {card.ability.extra.hand_mod} }
 end
 
 function jokerInfo.generate_ui(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
 	G.FUNCS.generate_legendary_desc(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
 end
 
-local function textIsFlush(text)
-	if text == "Flush" or text == "Straight Flush" or text == "Royal Flush" or text == "Flush House" or text == "Flush Five" then
-		return true
-	else
-		return false
-	end
-end
-
 function jokerInfo.calculate(self, card, context)
-	if context.cardarea == G.jokers and context.before and not card.debuff then
-		if next(context.poker_hands["Flush"]) then
-			ease_hands_played(1)
-			return {
-				card = card,
-				message = localize('k_plus_hand'),
-				colour = G.C.BLUE
-			}
-		end
+	if card.debuff then return end
+
+	if context.cardarea == G.jokers and context.before and next(context.poker_hands['Flush']) then
+		ease_hands_played(card.ability.extra.hand_mod)
+		return {
+			card = card,
+			message = localize('k_plus_hand'),
+			colour = G.C.BLUE
+		}
 	end
 end
 

--- a/items/jokers/red.lua
+++ b/items/jokers/red.lua
@@ -16,9 +16,10 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gappie } }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.prob)
     return {
         vars = {
-            SMODS.get_probability_vars(card, 1, card.ability.extra.prob),
+            num, dom,
             localize(G.GAME and G.GAME.wigsaw_suit or card.ability.extra.suit_conv, 'suits_plural'),
             colours = {
                 G.C.SUITS[G.GAME and G.GAME.wigsaw_suit or card.ability.extra.suit_conv]

--- a/items/jokers/red.lua
+++ b/items/jokers/red.lua
@@ -1,8 +1,10 @@
 local jokerInfo = {
     name = 'Why Are You Red?',
     config = {
-        suit_conv = "Hearts",
-        prob = 4
+        extra = {
+            suit_conv = "Hearts",
+            prob = 4
+        }
     },
     rarity = 2,
     cost = 5,
@@ -14,27 +16,38 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gappie } }
-    return { vars = { G.GAME.probabilities.normal, card.ability.prob, localize(G.GAME and G.GAME.wigsaw_suit or "Hearts", 'suits_plural'), colours = {G.C.SUITS[G.GAME and G.GAME.wigsaw_suit or "Hearts"]} } }
+    return {
+        vars = {
+            SMODS.get_probability_vars(card, 1, card.ability.extra.prob), 
+            localize(G.GAME and G.GAME.wigsaw_suit or card.ability.extra.suit_conv, 'suits_plural'),
+            colours = {
+                G.C.SUITS[G.GAME and G.GAME.wigsaw_suit or card.ability.extra.suit_conv]
+            }
+        }
+    }
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.cardarea == G.jokers and context.after and not card.debuff then
-        if pseudorandom('red') < G.GAME.probabilities.normal / card.ability.prob then
-            check_for_unlock({ type = "activate_red" })
-            card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_red', vars = {string.upper(localize(G.GAME and G.GAME.wigsaw_suit or "Hearts", 'suits_plural'))}}})
-            for i=1, #context.scoring_hand do
-                local percent = 1.15 - (i-0.999)/(#context.scoring_hand-0.998)*0.3
-                G.E_MANAGER:add_event(Event({trigger = 'before',delay = 0.15,func = function() context.scoring_hand[i]:flip();play_sound('card1', percent);context.scoring_hand[i]:juice_up(0.3, 0.3);return true end }))
-            end
-            for i=1, #context.scoring_hand do
-                G.E_MANAGER:add_event(Event({trigger = 'before',delay = 0.1,func = function() context.scoring_hand[i]:change_suit(G.GAME and G.GAME.wigsaw_suit or card.ability.suit_conv);return true end }))
-            end
-            for i=1, #context.scoring_hand do
-                local percent = 0.85 + (i-0.999)/(#context.scoring_hand-0.998)*0.3
-                G.E_MANAGER:add_event(Event({trigger = 'before',delay = 0.15,func = function() context.scoring_hand[i]:flip();play_sound('tarot2', percent, 0.6);context.scoring_hand[i]:juice_up(0.3, 0.3);return true end }))
-            end
-            delay(0.8)
+    if card.debuff or context.blueprint then return end
+
+    if context.cardarea == G.jokers and context.after and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_red'), 1, card.ability.extra.prob) then
+        check_for_unlock({ type = "activate_red" })
+        card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_red', vars = {string.upper(localize(G.GAME and G.GAME.wigsaw_suit or "Hearts", 'suits_plural'))}}})
+        
+        for i=1, #context.scoring_hand do
+            local percent = 1.15 - (i-0.999)/(#context.scoring_hand-0.998)*0.3
+            G.E_MANAGER:add_event(Event({trigger = 'before',delay = 0.15,func = function() context.scoring_hand[i]:flip();play_sound('card1', percent);context.scoring_hand[i]:juice_up(0.3, 0.3);return true end }))
         end
+
+        for i=1, #context.scoring_hand do
+            G.E_MANAGER:add_event(Event({trigger = 'before',delay = 0.1,func = function() context.scoring_hand[i]:change_suit(G.GAME and G.GAME.wigsaw_suit or card.ability.extra.suit_conv);return true end }))
+        end
+
+        for i=1, #context.scoring_hand do
+            local percent = 0.85 + (i-0.999)/(#context.scoring_hand-0.998)*0.3
+            G.E_MANAGER:add_event(Event({trigger = 'before',delay = 0.15,func = function() context.scoring_hand[i]:flip();play_sound('tarot2', percent, 0.6);context.scoring_hand[i]:juice_up(0.3, 0.3);return true end }))
+        end
+        delay(0.8)
     end
 end
 

--- a/items/jokers/red.lua
+++ b/items/jokers/red.lua
@@ -18,7 +18,7 @@ function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gappie } }
     return {
         vars = {
-            SMODS.get_probability_vars(card, 1, card.ability.extra.prob), 
+            SMODS.get_probability_vars(card, 1, card.ability.extra.prob),
             localize(G.GAME and G.GAME.wigsaw_suit or card.ability.extra.suit_conv, 'suits_plural'),
             colours = {
                 G.C.SUITS[G.GAME and G.GAME.wigsaw_suit or card.ability.extra.suit_conv]
@@ -30,7 +30,7 @@ end
 function jokerInfo.calculate(self, card, context)
     if card.debuff or context.blueprint then return end
 
-    if context.cardarea == G.jokers and context.after and SMODS.pseudorandom_probability(G.GAME.blind, pseudoseed('csau_red'), 1, card.ability.extra.prob) then
+    if context.cardarea == G.jokers and context.after and SMODS.pseudorandom_probability(card, pseudoseed('csau_red'), 1, card.ability.extra.prob) then
         check_for_unlock({ type = "activate_red" })
         card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_red', vars = {string.upper(localize(G.GAME and G.GAME.wigsaw_suit or "Hearts", 'suits_plural'))}}})
         

--- a/items/jokers/speen.lua
+++ b/items/jokers/speen.lua
@@ -38,36 +38,35 @@ local jokerInfo = {
 }
 
 function jokerInfo.loc_vars(self, info_queue, card)
-	info_queue[#info_queue+1] = {key = "wheel2", set = "Other", vars = {G.GAME.probabilities.normal}}
+	local num, _ =  SMODS.get_probability_vars(card, 1, 1)
+	info_queue[#info_queue+1] = {key = "wheel2", set = "Other", vars = {num}}
 	info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
 	info_queue[#info_queue+1] = {key = "codercredit", set = "Other", vars = { G.csau_team.dps } }
 end
 
 function jokerInfo.calculate(self, card, context)
-	if context.reroll_shop and not card.getting_sliced and not card.debuff and not (context.blueprint_card or card).getting_sliced and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
-		G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
-		G.E_MANAGER:add_event(Event({
-			func = (function()
-				G.E_MANAGER:add_event(Event({
-					func = function() 
-						local card = create_card('Tarot',G.consumeables, nil, nil, nil, nil, 'c_wheel_of_fortune', 'car')
-						card:add_to_deck()
-						G.consumeables:emplace(card)
-						G.GAME.consumeable_buffer = 0
-						return true
-					end}))   
-					card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = localize('k_speen'), colour = G.C.PURPLE})
-				return true
-			end)}
-		))
+	if card.debuff or not context.reroll_shop or #G.consumeables.cards + G.GAME.consumeable_buffer >= G.consumeables.config.card_limit then 
+		return 
 	end
-end
 
-function jokerInfo.update(self, dt)
+	G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
+	G.E_MANAGER:add_event(Event({
+		func = (function()
+			G.E_MANAGER:add_event(Event({
+				func = function() 
+					local new_card = create_card('Tarot', G.consumeables, nil, nil, nil, nil, 'c_wheel_of_fortune', 'car')
+					new_card:add_to_deck()
+					G.consumeables:emplace(new_card)
+					G.GAME.consumeable_buffer = 0
+					return true
+				end}))
+				card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = localize('k_speen'), colour = G.C.PURPLE})
+			return true
+		end)}
+	))
 end
 
 local loveUpdateReference = love.update
-
 function love.update(dt)
 	if mod.speenTimer and G.SETTINGS.GAMESPEED then
 		mod.speenTimer = (mod.speenTimer + (dt * (G.SETTINGS.GAMESPEED / 4))) % (math.pi * 4)

--- a/items/jokers/sprunk.lua
+++ b/items/jokers/sprunk.lua
@@ -33,14 +33,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.donk } }
-    return {
-        vars = {
-            card.ability.extra.mult_mod,
-            card.ability.extra.prob_mod,
-            SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob),
-            card.ability.extra.mult,
-        }
-    }
+    local num, dom = SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob)
+    return { vars = { card.ability.extra.mult_mod, card.ability.extra.prob_mod, num, dom, card.ability.extra.mult } }
 end
 
 function jokerInfo.in_pool(self, args)

--- a/items/jokers/sprunk.lua
+++ b/items/jokers/sprunk.lua
@@ -33,7 +33,14 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.donk } }
-    return { vars = {card.ability.extra.mult_mod, card.ability.extra.prob_mod, G.FUNCS.csau_add_chance(card.ability.extra.prob_extra, {multiply = true}), card.ability.extra.prob, card.ability.extra.mult }}
+    return {
+        vars = {
+            card.ability.extra.mult_mod,
+            card.ability.extra.prob_mod,
+            SMODS.get_probability_vars(card, card.ability.extra.prob_extra, card.ability.extra.prob),
+            card.ability.extra.mult,
+        }
+    }
 end
 
 function jokerInfo.in_pool(self, args)
@@ -378,25 +385,29 @@ local function fake_crash()
 end
 
 function jokerInfo.calculate(self, card, context)
-    local bad_context = context.repetition or context.individual or context.blueprint
-    if context.cardarea == G.jokers and context.before and not card.debuff and not bad_context and SMODS.food_expires(context) then
-        if pseudorandom('essenceofcrash') < G.FUNCS.csau_add_chance(card.ability.extra.prob_extra, {multiply = true}) / card.ability.extra.prob then
-            if pseudorandom('sprunkdit') < (card.ability.hidden_prob.manip and G.GAME.probabilities.normal or card.ability.hidden_prob.non_manip_rate) / card.ability.hidden_prob.prob then
-                send("RUN DELETED! LOL")
-                check_for_unlock({ type = "get_sprunked" })
-                if G.STAGE == G.STAGES.RUN then
-                    G.STATE = G.STATES.GAME_OVER
-                    G.STATE_COMPLETE = false
-                end
-                remove_save()
-            else
-                G:save_progress()
-            end
-            G:save_settings()
-            fake_crash()
-        end
+    if card.debuff or context.cardarea ~= G.jokers then
+        return
     end
-    if context.joker_main and context.cardarea == G.jokers and not card.debuff and to_big(card.ability.extra.mult) > to_big(0) and not bad_context then
+
+    if context.before and SMODS.food_expires() and SMODS.pseudorandom_probability(card, pseudoseed('csau_sprunk_crash'), card.ability.extra.prob_extra, card.ability.extra.prob) then
+        local numerator = card.ability.hidden_prob.manip and 1 or card.ability.hidden_prob.non_manip_rate
+        if SMODS.pseudorandom_probability(card, pseudoseed('csau_sprunk_delete'), numerator, card.ability.hidden_prob.prob) then
+            send("RUN DELETED! LOL")
+            check_for_unlock({ type = "get_sprunked" })
+            if G.STAGE == G.STAGES.RUN then
+                G.STATE = G.STATES.GAME_OVER
+                G.STATE_COMPLETE = false
+            end
+            remove_save()
+        else
+            G:save_progress()
+        end
+
+        G:save_settings()
+        fake_crash()
+    end
+
+    if context.joker_main and to_big(card.ability.extra.mult) > to_big(0) then
         return {
             mult = card.ability.extra.mult,
         }
@@ -406,26 +417,31 @@ end
 local ed_ref = ease_dollars
 function ease_dollars(mod, instant)
     ed_ref(mod, instant)
-    if to_big(mod) < to_big(0) then
-        local sprunk = SMODS.find_card("j_csau_sprunk")
-        if #sprunk > 0 then
-            for i, v in ipairs(sprunk) do
-                if not v.debuff then
-                    G.E_MANAGER:add_event(Event({
-                        trigger = 'immediate',
-                        blockable = false,
-                        blocking = true,
-                        func = function()
-                            v.ability.extra.mult = v.ability.extra.mult + (-mod * v.ability.extra.mult_mod)
-                            if SMODS.food_expires() then
-                                v.ability.extra.prob_extra = v.ability.extra.prob_extra + (-mod * v.ability.extra.prob_mod)
-                            end
-                            card_eval_status_text(v, 'extra', nil, nil, nil, {message = localize{type='variable',key='a_mult',vars={v.ability.extra.mult}}, colour = G.C.IMPORTANT})
-                            return true
-                        end
-                    }))
+    if to_big(mod) >= to_big(0) then
+        return
+    end
+    
+    local sprunks = SMODS.find_card("j_csau_sprunk")
+    if not next(sprunks) then
+        return
+    end
+
+    for _, v in ipairs(sprunks) do
+        if not v.debuff then
+            G.E_MANAGER:add_event(Event({
+                trigger = 'immediate',
+                blockable = false,
+                blocking = true,
+                func = function()
+                    v.ability.extra.mult = v.ability.extra.mult + (-mod * v.ability.extra.mult_mod)
+                    if SMODS.food_expires() then
+                        v.ability.extra.prob_extra = v.ability.extra.prob_extra + (-mod * v.ability.extra.prob_mod)
+                    end
+
+                    card_eval_status_text(v, 'extra', nil, nil, nil, {message = localize{type='variable',key='a_mult',vars={v.ability.extra.mult}}, colour = G.C.IMPORTANT})
+                    return true
                 end
-            end
+            }))
         end
     end
 end

--- a/items/jokers/vinewrestle.lua
+++ b/items/jokers/vinewrestle.lua
@@ -16,7 +16,7 @@ end
 function jokerInfo.calculate(self, card, context)
     local bad_context = context.repetition or context.individual or context.blueprint
     if context.end_of_round and G.GAME.blind.boss and not card.debuff and not bad_context then
-        local key, free_tag, color = G.FUNCS.csau_get_free_tag('joker', 'ITSSOMOAJOE')
+        local key, color = G.FUNCS.csau_get_tag('joker', 'ITSSOMOAJOE')
         card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_plus_one')..G.localization.descriptions["Tag"][key].name, colour = color})
         G.E_MANAGER:add_event(Event({
             trigger = 'before',

--- a/items/ortalab/jokers/expiredmeds.lua
+++ b/items/ortalab/jokers/expiredmeds.lua
@@ -1,8 +1,6 @@
 local jokerInfo = {
     name = 'Expired',
     config = {
-        id = nil,
-        timesSold = nil,
         extra = {
             chips = 50,
             chips_mod = 50,
@@ -19,25 +17,16 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.wario } }
-    return { vars = {card.ability.extra.chips_mod, G.GAME.probabilities.normal, card.ability.extra.chance, card.ability.extra.chips} }
+    return { vars = {card.ability.extra.chips_mod, SMODS.get_probability_vars(card, 1, card.ability.extra.chance), card.ability.extra.chips} }
 end
 
-function jokerInfo.add_to_deck(self, card)
-    if not card.ability.id then
-        if not G.GAME.uniqueExpiredMedsAcquired then
-            G.GAME.uniqueExpiredMedsAcquired = 1
-        else
-            G.GAME.uniqueExpiredMedsAcquired = G.GAME.uniqueExpiredMedsAcquired + 1
-        end
-        card.ability.id = G.GAME.uniqueExpiredMedsAcquired
-    else
-        local other_dc = SMODS.find_card('j_csau_expiredmeds')
-        if other_dc[1] then
-            if other_dc[1].Mid.ability.id == card.ability.id then
-                G.GAME.uniqueExpiredMedsAcquired = G.GAME.uniqueExpiredMedsAcquired + 1
-                card.ability.id = G.GAME.uniqueExpiredMedsAcquired
-            end
-        end
+function jokerInfo.add_to_deck(self, card, from_debuff)
+    if from_debuff then return end
+
+    if not card.ability.extra.csau_meds_id then
+        G.GAME.csau_unique_meds_acquired = (G.GAME.csau_unique_meds_acquired or 0) + 1
+        card.ability.extra.csau_meds_id = G.GAME.csau_unique_meds_acquired
+        return
     end
 end
 
@@ -47,70 +36,27 @@ function jokerInfo.calculate(self, card, context)
             chips = card.ability.extra.chips
         }
     end
-    if context.selling_self then
-        local stop = false
-        if G.GAME.sellShopJokersSold then
-            for i, v in ipairs(G.GAME.sellShopJokersSold) do
-                if v['id'] == card.ability.id then
-                    stop = true
-                end
-            end
-        end
-        if not stop then
-            if card.ability.timesSold then
-                card.ability.timesSold = card.ability.timesSold + 1
-            else
-                card.ability.timesSold = 1
-            end
-            if pseudorandom('buckshot') < G.GAME.probabilities.normal / card.ability.extra.chance then
-                card.ability.timesSold = 0
-            end
-            if not G.GAME.sellShopJokersSold then
-                G.GAME.sellShopJokersSold = {}
-            end
-            G.GAME.sellShopJokersSold[#G.GAME.sellShopJokersSold+1] = {key =card.config.center.key, id=card.ability.id, timesSold=card.ability.timesSold, edition=card.edition and card.edition.type or nil}
-            if G.GAME.spawnSellShopJokers then
-                G.GAME.spawnSellShopJokers = G.GAME.spawnSellShopJokers + 1
-            else
-                G.GAME.spawnSellShopJokers = 1
-            end
-            if card.ability.timesSold == 0 then
-                return {
-                    message = localize('k_reset'),
-                    colour = G.C.IMPORTANT
-                }
-            end
+
+    if context.selling_self and not next(SMODS.find_card('j_csau_expiredmeds')) then
+        G.GAME.csau_sold_meds = {
+            key = card.config.center.key,
+            edition = card.edition and card.edition.type or nil
+        }
+
+        if SMODS.pseudorandom_probability(card, pseudoseed('csau_expired_reset'), 1, card.ability.extra.chance) then
+            G.GAME.csau_unique_meds_acquired = 0
+            return {
+                message = localize('k_reset'),
+                colour = G.C.IMPORTANT
+            }
         end
     end
-end
 
-function jokerInfo.update(self, card)
-    if card.area and card.area.config.type == "shop" and G.GAME.sellShopJokersSold then
-        if #G.GAME.sellShopJokersSold > 0 and not card.ability.id and not card.ability.timesSold then
-            local meds = G.GAME.sellShopJokersSold[1]
-            local id = meds['id']
-            if meds['edition'] then
-                if meds['edition'] == "foil" then
-                    card:set_edition({foil = true}, true, true)
-                elseif meds['edition'] == "holo" then
-                    card:set_edition({holo = true}, true, true)
-                elseif meds['edition'] == "polychrome" then
-                    card:set_edition({polychrome = true}, true, true)
-                elseif meds['edition'] == "negative" then
-                    card:set_edition({negative = true}, true, true)
-                end
-            end
-            card.ability.id = id
-            local timesSold = meds['timesSold']
-            card.ability.timesSold = timesSold
-            local newchips = card.ability.extra.chips + (card.ability.extra.chips_mod * card.ability.timesSold)
-            send(newchips)
-            if card.ability.timesSold == 0 then
-                newchips = self.config.extra.chips
-            end
-            send(newchips)
-            card.ability.extra.chips = newchips
-            table.remove(G.GAME.sellShopJokersSold, 1)
+    if context.csau_created_card and context.area == G.shop_jokers and G.GAME.csau_sold_meds then
+        context.csau_created_card:set_ability(G.P_CENTERS[G.GAME.csau_sold_meds.key], nil, nil)
+        context.csau_created_card.ability.extra.chips = context.csau_created_card.ability.extra.chips + context.csau_created_card.ability.extra.chips_mod * G.GAME.csau_unique_meds_acquired
+        if G.GAME.csau_sold_meds.edition then
+            context.csau_created_card:set_edition({[G.GAME.csau_sold_meds.edition] = true}, true, true)
         end
     end
 end

--- a/items/ortalab/jokers/expiredmeds.lua
+++ b/items/ortalab/jokers/expiredmeds.lua
@@ -17,7 +17,8 @@ local jokerInfo = {
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.wario } }
-    return { vars = {card.ability.extra.chips_mod, SMODS.get_probability_vars(card, 1, card.ability.extra.chance), card.ability.extra.chips} }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.chance)
+    return { vars = {card.ability.extra.chips_mod, num, dom, card.ability.extra.chips} }
 end
 
 function jokerInfo.add_to_deck(self, card, from_debuff)

--- a/items/sleeves/sleeve_varg.lua
+++ b/items/sleeves/sleeve_varg.lua
@@ -1,14 +1,21 @@
 local sleeveInfo = {
     name = 'Varg Sleeve',
-    config = { probability_mult = 2, probability_mult_alt = 1.5, csau_jokers_rate = 2, csau_all_rate = 2, hand_size = -1, },
+    config = { 
+        probability_mult = 2,
+        probability_mult_alt = 1.5,
+        csau_jokers_rate = 2,
+        csau_all_rate = 2,
+        hand_size = -1
+    },
     unlocked = false,
     unlock_condition = { deck = "b_csau_varg", stake = "stake_green" },
 }
 
-sleeveInfo.loc_vars = function(self, info_queue)
+function sleeveInfo.loc_vars(self, info_queue)
     if info_queue then
         info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.keku } }
     end
+
     local key, vars
     if self.get_current_deck_key() == "b_csau_varg" then
         key = self.key .. "_alt"
@@ -17,10 +24,11 @@ sleeveInfo.loc_vars = function(self, info_queue)
         key = self.key
         vars = {self.config.hand_size, self.config.probability_mult, self.config.csau_jokers_rate}
     end
+
     return { key = key, vars = vars }
 end
 
-sleeveInfo.apply = function(self, sleeve)
+function sleeveInfo.apply(self, sleeve)
     if (sleeve.config.csau_jokers_rate) then
         G.GAME.starting_params.csau_jokers_rate = G.GAME.starting_params.csau_jokers_rate or 1
         G.GAME.starting_params.csau_jokers_rate = G.GAME.starting_params.csau_jokers_rate * sleeve.config.csau_jokers_rate
@@ -28,15 +36,19 @@ sleeveInfo.apply = function(self, sleeve)
     if self.get_current_deck_key() == "b_csau_varg" then
         G.GAME.starting_params.csau_all_rate = G.GAME.starting_params.csau_all_rate or 1
         G.GAME.starting_params.csau_all_rate = G.GAME.starting_params.csau_all_rate * sleeve.config.csau_all_rate
-        for k, v in pairs(G.GAME.probabilities) do
-            G.GAME.probabilities[k] = v * sleeve.config.probability_mult_alt
-        end
+        sleeve.config.active_mod = sleeve.config.probability_mult_alt
     else
-        for k, v in pairs(G.GAME.probabilities) do
-            G.GAME.probabilities[k] = v * sleeve.config.probability_mult
-        end
+        sleeve.config.active_mod = sleeve.config.probability_mult
     end
     CardSleeves.Sleeve.apply(sleeve)
+end
+
+function sleeveInfo.calculate(self, sleeve, context)
+    if context.mod_probability then
+        return {
+            numerator = context.numerator * seleve.config.active_mod
+        }
+    end
 end
 
 return sleeveInfo

--- a/items/stands/diamond_echoes_2.lua
+++ b/items/stands/diamond_echoes_2.lua
@@ -67,10 +67,6 @@ local get_first_non_matching = function(suit, hand)
     return nil
 end
 
-function consumInfo.on_evolve(self, old_stand, new_stand)
-    sendDebugMessage('hello')
-end
-
 function consumInfo.calculate(self, card, context)
     local bad_context = context.repetition or context.blueprint or context.individual or context.retrigger_joker
     if context.before and not card.debuff and not bad_context then

--- a/items/stands/vento_gold.lua
+++ b/items/stands/vento_gold.lua
@@ -1,6 +1,6 @@
 local consumInfo = {
     name = 'Gold Experience',
-    set = 'csau_Stand',
+    set = 'Stand',
     config = {
         stand_mask = true,
         aura_colors = { 'fff679DC' , 'f9d652DC' },
@@ -10,17 +10,24 @@ local consumInfo = {
         }
     },
     cost = 4,
-    rarity = 'csau_StandRarity',
-    alerted = true,
+    rarity = 'arrow_StandRarity',
     hasSoul = true,
-    in_progress = true,
     part = 'vento',
+    blueprint_compat = true
 }
 
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_gold
-    info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.wario } }
-    return { vars = { G.GAME.probabilities.normal, card.ability.extra.prob, localize(G.GAME and G.GAME.wigsaw_suit or "Hearts", 'suits_plural'), colours = {G.C.SUITS[G.GAME and G.GAME.wigsaw_suit or "Hearts"]}} }
+    info_queue[#info_queue+1] = {key = "artistcredit", set = "Other", vars = { G.jojobal_mod_team.wario } }
+    return { 
+        vars = { 
+            SMODS.get_probability_vars(card, 1, card.ability.extra.prob),
+            localize(G.GAME and G.GAME.wigsaw_suit or "Hearts", 'suits_plural'),
+            colours = {
+                G.C.SUITS[G.GAME and G.GAME.wigsaw_suit or "Hearts"]
+            }
+        } 
+    }
 end
 
 function consumInfo.in_pool(self, args)
@@ -32,11 +39,11 @@ function consumInfo.in_pool(self, args)
 end
 
 function consumInfo.calculate(self, card, context)
-    local bad_context = context.repetition or context.blueprint or context.individual or context.retrigger_joker
-    if context.before and not card.debuff and not bad_context then
+    if context.before and not card.debuff then
         local gold = {}
         for k, v in ipairs(context.scoring_hand) do
-            if v:is_suit(G.GAME and G.GAME.wigsaw_suit or "Hearts") and pseudorandom('thisisrequiem') < G.GAME.probabilities.normal / card.ability.extra.prob then
+            if v.config.center.key ~= 'm_gold' and v:is_suit(G.GAME and G.GAME.wigsaw_suit or "Hearts") 
+            and SMODS.pseudorandom_probability(card, pseudoseed('csau_goldexperience'), 1, card.ability.extra.prob) then
                 gold[#gold+1] = v
                 v:set_ability(G.P_CENTERS.m_gold, nil, true)
                 G.E_MANAGER:add_event(Event({
@@ -47,14 +54,18 @@ function consumInfo.calculate(self, card, context)
                 }))
             end
         end
+
         if #gold > 0 then
+            local flare_card = context.blueprint_card or card
             return {
                 func = function()
-                    G.FUNCS.csau_flare_stand_aura(card, 0.38)
+                    G.FUNCS.flare_stand_aura(flare_card, 0.50)
                 end,
-                message = localize('k_gold_exp'),
-                colour = G.C.MONEY,
-                card = card
+                extra = {
+                    message = localize('k_gold_exp'),
+                    colour = G.C.MONEY,
+                    card = flare_card
+                }
             }
         end
     end

--- a/items/stands/vento_gold.lua
+++ b/items/stands/vento_gold.lua
@@ -1,6 +1,6 @@
 local consumInfo = {
     name = 'Gold Experience',
-    set = 'Stand',
+    set = 'csau_Stand',
     config = {
         stand_mask = true,
         aura_colors = { 'fff679DC' , 'f9d652DC' },
@@ -10,7 +10,7 @@ local consumInfo = {
         }
     },
     cost = 4,
-    rarity = 'arrow_StandRarity',
+    rarity = 'csau_StandRarity',
     hasSoul = true,
     part = 'vento',
     blueprint_compat = true
@@ -19,9 +19,10 @@ local consumInfo = {
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_gold
     info_queue[#info_queue+1] = {key = "artistcredit", set = "Other", vars = { G.jojobal_mod_team.wario } }
-    return { 
-        vars = { 
-            SMODS.get_probability_vars(card, 1, card.ability.extra.prob),
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.prob)
+    return {
+        vars = {
+            num, dom,
             localize(G.GAME and G.GAME.wigsaw_suit or "Hearts", 'suits_plural'),
             colours = {
                 G.C.SUITS[G.GAME and G.GAME.wigsaw_suit or "Hearts"]

--- a/items/stands/vento_gold_requiem.lua
+++ b/items/stands/vento_gold_requiem.lua
@@ -1,6 +1,6 @@
 local consumInfo = {
     name = 'Gold Experience Requiem',
-    set = 'Stand',
+    set = 'csau_Stand',
     config = {
         stand_mask = true,
         aura_colors = { '99d3ffDC' , 'd3f5fbDC' },
@@ -10,7 +10,7 @@ local consumInfo = {
         }
     },
     cost = 10,
-    rarity = 'arrow_EvolvedRarity',
+    rarity = 'csau_EvolvedRarity',
     hasSoul = true,
     part = 'vento',
     blueprint_compat = true,

--- a/items/stands/vento_gold_requiem.lua
+++ b/items/stands/vento_gold_requiem.lua
@@ -1,53 +1,66 @@
 local consumInfo = {
     name = 'Gold Experience Requiem',
-    set = 'csau_Stand',
+    set = 'Stand',
     config = {
         stand_mask = true,
         aura_colors = { '99d3ffDC' , 'd3f5fbDC' },
         evolved = true,
         extra = {
-            chance = 0,
-            divide = 5,
+            chance = 5,
         }
     },
     cost = 10,
-    rarity = 'csau_EvolvedRarity',
-    alerted = true,
+    rarity = 'arrow_EvolvedRarity',
     hasSoul = true,
-    in_progress = true,
     part = 'vento',
+    blueprint_compat = true,
 }
 
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_gold
-    info_queue[#info_queue+1] = {key = "csau_artistcredit_2", set = "Other", vars = { G.csau_team.reda, G.csau_team.wario } }
-    return { vars = { card.ability.extra.chance, card.ability.extra.divide, G.GAME.probabilities.normal}}
+    info_queue[#info_queue+1] = {key = "artistcredit_2", set = "Other", vars = { G.jojobal_mod_team.reda, G.jojobal_mod_team.wario } }
+    return { vars = { SMODS.get_probability_vars(card, 1, card.ability.extra.chance) }}
 end
 
 function consumInfo.in_pool(self, args)
     if next(SMODS.find_card('j_showman')) then
         return true
     end
-    return (not G.GAME.used_jokers['c_csau_vento_gold'])
+    return (not G.GAME.used_jokers['c_jojobal_vento_gold'])
 end
 
 function consumInfo.calculate(self, card, context)
-    local bad_context = context.repetition or context.blueprint or context.individual or context.retrigger_joker
-    if context.before and not card.debuff and not bad_context then
-        local gold = {}
-        for k, v in ipairs(context.scoring_hand) do
-            if v.ability.effect == "Gold Card" then
-                gold[#gold+1] = v
+    if context.before and not card.debuff then
+        local tick_cards = {}
+        for _, v in ipairs(context.scoring_hand) do
+            if SMODS.has_enhancement(v, 'm_gold') and SMODS.pseudorandom_probability(card, pseudoseed('csau_ge_requiem'), 1, card.ability.extra.chance) then
+                tick_cards[#tick_cards+1] = v
             end
         end
-        if pseudorandom('thisisrequiem') < G.FUNCS.csau_add_chance(card.ability.extra.chance+#gold, {multiply = true}) / card.ability.extra.divide then
+
+        local levels = #tick_cards
+        if levels > 0 then
+            for i = 1, levels do
+                G.E_MANAGER:add_event(Event({ 
+                    trigger = 'before',
+                    delay = 0.3,
+                    func = function() 
+                        tick_cards[i]:juice_up()
+                        play_sound('card1')
+                    return true 
+                end })) 
+            end
+
+            local flare_card = context.blueprint_card or card
             return {
                 func = function()
-                    G.FUNCS.csau_flare_stand_aura(card, 0.38)
+                    G.FUNCS.flare_stand_aura(flare_card, 0.50)
                 end,
-                card = card,
-                level_up = true,
-                message = localize('k_level_up_ex')
+                extra = {
+                    card = flare_card,
+                    level_up = levels,
+                    message = localize{type = 'variable', key = 'a_multilevel', vars = {levels}},
+                }
             }
         end
     end

--- a/items/stands/vento_metallica.lua
+++ b/items/stands/vento_metallica.lua
@@ -1,6 +1,6 @@
 local consumInfo = {
     name = 'Metallica',
-    set = 'Stand',
+    set = 'csau_Stand',
     config = {
         stand_mask = true,
         aura_colors = { 'F97C87DA', 'CE3749DA' },
@@ -9,7 +9,7 @@ local consumInfo = {
         }
     },
     cost = 4,
-    rarity = 'arrow_StandRarity',
+    rarity = 'csau_StandRarity',
     hasSoul = true,
     blueprint_compat = false,
     part = 'vento',

--- a/items/stands/vento_metallica.lua
+++ b/items/stands/vento_metallica.lua
@@ -1,6 +1,6 @@
 local consumInfo = {
     name = 'Metallica',
-    set = 'csau_Stand',
+    set = 'Stand',
     config = {
         stand_mask = true,
         aura_colors = { 'F97C87DA', 'CE3749DA' },
@@ -9,73 +9,61 @@ local consumInfo = {
         }
     },
     cost = 4,
-    rarity = 'csau_StandRarity',
-    alerted = true,
+    rarity = 'arrow_StandRarity',
     hasSoul = true,
-    in_progress = true,
+    blueprint_compat = false,
     part = 'vento',
 }
 
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = G.P_CENTERS.m_steel
     info_queue[#info_queue+1] = G.P_CENTERS.m_glass
-    info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
-end
-
-local function detect_jacks(scoring_hand)
-    for k, v in ipairs(scoring_hand) do
-        if v:get_id() == 11 and v.ability.effect == "Base" then
-            return true
-        end
-    end
-    return false
+    info_queue[#info_queue+1] = {key = "artistcredit", set = "Other", vars = { G.jojobal_mod_team.gote } }
 end
 
 function consumInfo.calculate(self, card, context)
-    local bad_context = context.repetition or context.blueprint or context.individual or context.retrigger_joker
-    if context.before and not card.debuff and not bad_context then
-        if detect_jacks(context.full_hand) then
-            for i, v in ipairs(context.full_hand) do
-                if v:get_id() == 11 and v.ability.effect == "Base" then
-                    v:set_ability(G.P_CENTERS.m_steel, nil, true)
-                    G.E_MANAGER:add_event(Event({
-                        func = function()
-                            v:juice_up()
-                            return true
-                        end
-                    }))
-                end
+    if context.blueprint or context.retrigger_joker or card.debuff then return end
+
+    if context.before then
+        local transformed = 0
+        for _, v in ipairs(context.full_hand) do
+            if v.base.value == 'Jack' and v.config.center.key == 'c_base' then
+                transformed = transformed + 1
+                v:set_ability(G.P_CENTERS.m_steel, nil, true)
+                G.E_MANAGER:add_event(Event({
+                    func = function()
+                        v:juice_up()
+                        return true
+                    end
+                }))
             end
+        end
+        if transformed > 0 then
             return {
                 func = function()
-                    G.FUNCS.csau_flare_stand_aura(card, 0.38)
+                    G.FUNCS.flare_stand_aura(card, 0.50)
                 end,
-                message = localize('k_metal'),
-                card = card,
+                extra = {
+                    message = localize('k_metal'),
+                    card = card,
+                }
             }
         end
     end
-    bad_context = context.repetition or context.blueprint or context.retrigger_joker
-    if context.individual and context.cardarea == G.play and not card.debuff and not bad_context then
-        if context.other_card:get_id() == 11 and context.other_card.ability.effect == "Steel Card" then
+
+    if context.check_enhancement then
+		if context.other_card.config.center.key == 'm_steel' and context.other_card.base.value == 'Jack' then
             return {
-                func = function()
-                    G.FUNCS.csau_flare_stand_aura(card, 0.38)
-                end,
-                xmult = (next(SMODS.find_card("j_csau_plaguewalker")) and 3 or card.ability.extra.x_mult),
-                card = context.other_card
+                ['m_glass'] = true,
             }
         end
-    end
-    bad_context = context.repetition or context.blueprint or context.individual
-    if context.destroying_card and not bad_context then
-        if context.destroying_card:get_id() == 11 and context.destroying_card.ability.effect == "Steel Card" then
-            if pseudorandom('metallica') < G.GAME.probabilities.normal / (next(SMODS.find_card("j_csau_plaguewalker")) and 2 or 4) then
-                return true
-            end
+	end
+
+    if context.individual and context.cardarea == G.play and not card.debuff and not context.repetition then
+        if context.other_card.config.center.key == 'm_steel'and context.other_card.base.value == 'Jack' then
+            G.FUNCS.flare_stand_aura(card, 0.50)
         end
     end
 end
-
 
 return consumInfo

--- a/items/vhs/alienpi.lua
+++ b/items/vhs/alienpi.lua
@@ -28,11 +28,8 @@ local consumInfo = {
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gong } }
-    return { vars = {
-        card.ability.extra.x_mult,
-        card.ability.extra.chance_mod,
-        SMODS.get_probability_vars(card, card.ability.extra.chance, card.ability.extra.rate),
-        card.ability.extra.runtime - card.ability.extra.uses } }
+    local num, dom = SMODS.get_probability_vars(card, card.ability.extra.chance, card.ability.extra.rate)
+    return { vars = { card.ability.extra.x_mult, card.ability.extra.chance_mod, num, dom, card.ability.extra.runtime - card.ability.extra.uses } }
 end
 
 function consumInfo.calculate(self, card, context)

--- a/items/vhs/devilstory.lua
+++ b/items/vhs/devilstory.lua
@@ -10,7 +10,7 @@ local consumInfo = {
         destroyed = false,
         extra = {
             dollars = 3,
-            runtime = 3,
+            runtime = 10,
             uses = 0,
             ach_enhancement = 'm_gold',
             ach_count = 5
@@ -38,7 +38,7 @@ end
 function consumInfo.calculate(self, card, context)
     if card.debuff or context.blueprint or not card.ability.activated then return end
 
-    if context.before and #context.scoring_hand >= card.abiltiy.extra.ach_count then
+    if context.before and #context.scoring_hand >= card.ability.extra.ach_count then
         local ach = 0
         for _, v in ipairs(context.scoring_hand) do
             local enhancements = SMODS.get_enhancements(v)
@@ -47,7 +47,7 @@ function consumInfo.calculate(self, card, context)
             end
         end
 
-        if ach > card.abiltiy.extra.ach_count then
+        if ach >= card.ability.extra.ach_count then
             check_for_unlock({ type = 'high_horse' })
         end
     end

--- a/items/vhs/devilstory.lua
+++ b/items/vhs/devilstory.lua
@@ -12,6 +12,8 @@ local consumInfo = {
             dollars = 3,
             runtime = 3,
             uses = 0,
+            ach_enhancement = 'm_gold',
+            ach_count = 5
         },
     },
     origin = {
@@ -34,31 +36,34 @@ function consumInfo.loc_vars(self, info_queue, card)
 end
 
 function consumInfo.calculate(self, card, context)
-    if card.ability.activated and context.individual and context.cardarea == G.play and not card.debuff and not context.blueprint and not context.repetition then
-        local count = 0
-        for i, v in ipairs(context.scoring_hand) do
-            if v.ability.effect ~= "Base" then
-                count = count + 1
-                return {
-                    dollars = card.ability.extra.dollars
-                }
+    if card.debuff or context.blueprint or not card.ability.activated then return end
+
+    if context.before and #context.scoring_hand >= card.abiltiy.extra.ach_count then
+        local ach = 0
+        for _, v in ipairs(context.scoring_hand) do
+            local enhancements = SMODS.get_enhancements(v)
+            if enhancements[card.ability.extra.ach_enhancement] then
+                ach = ach + 1
             end
         end
-        if count > 0 then
-            if count >= 5 then
-                check_for_unlock({ type = "high_horse" })
-            end
-            G.E_MANAGER:add_event(Event({
-                func = function()
-                    card.ability.extra.uses = card.ability.extra.uses+1
-                    if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
-                        G.FUNCS.destroy_tape(card)
-                        card.ability.destroyed = true
-                    end
-                    return true
+
+        if ach > card.abiltiy.extra.ach_count then
+            check_for_unlock({ type = 'high_horse' })
+        end
+    end
+
+    if to_big(card.ability.extra.uses) < to_big(card.ability.extra.runtime) and context.individual
+    and context.cardarea == G.play and next(SMODS.get_enhancements(context.other_card)) then
+        card.ability.extra.uses = math.max(0, card.ability.extra.uses + 1)
+        return {
+            dollars = card.ability.extra.dollars,
+            func = function()
+                if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
+                    G.FUNCS.destroy_tape(card)
+                    card.ability.destroyed = true
                 end
-            }))
-        end
+            end
+        }
     end
 end
 

--- a/items/vhs/nukie.lua
+++ b/items/vhs/nukie.lua
@@ -18,20 +18,19 @@ local consumInfo = {
 
 
 function consumInfo.loc_vars(self, info_queue, card)
-    info_queue[#info_queue+1] = {key = "wheel2", set = "Other", vars = {G.GAME.probabilities.normal}}
+    local num, _ =  SMODS.get_probability_vars(card, 1, 1)
+	info_queue[#info_queue+1] = {key = "wheel2", set = "Other", vars = {num}}
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.wario } }
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
 function consumInfo.calculate(self, card, context)
-    if context.using_consumeable then
-        if context.consumeable.config.center.key == 'c_wheel' then
-            card.ability.extra.uses = card.ability.extra.uses+1
-            if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
-                G.FUNCS.destroy_tape(card)
-                card.ability.destroyed = true
-            end
+    if context.using_consumeable and context.consumeable.config.center.key == 'c_wheel' then
+        card.ability.extra.uses = card.ability.extra.uses+1
+        if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
+            G.FUNCS.destroy_tape(card)
+            card.ability.destroyed = true
         end
     end
 end

--- a/items/vhs/sos.lua
+++ b/items/vhs/sos.lua
@@ -25,7 +25,8 @@ local consumInfo = {
 
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
-    return { vars = {  SMODS.get_probability_vars(card, 1, card.ability.extra.prob), card.ability.extra.x_mult, card.ability.extra.runtime-card.ability.extra.uses } }
+    local num, dom = SMODS.get_probability_vars(card, 1, card.ability.extra.prob)
+    return { vars = { num, dom, card.ability.extra.x_mult, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
 function consumInfo.calculate(self, card, context)

--- a/items/vhs/sos.lua
+++ b/items/vhs/sos.lua
@@ -25,19 +25,19 @@ local consumInfo = {
 
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
-    return { vars = { G.GAME.probabilities.normal, card.ability.extra.prob, card.ability.extra.x_mult, card.ability.extra.runtime-card.ability.extra.uses } }
+    return { vars = {  SMODS.get_probability_vars(card, 1, card.ability.extra.prob), card.ability.extra.x_mult, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
 function consumInfo.calculate(self, card, context)
-    if context.joker_main and card.ability.activated and pseudorandom('cult') < G.GAME.probabilities.normal / card.ability.extra.prob then
+    if context.joker_main and card.ability.activated and SMODS.pseudorandom_probability(card, pseudoseed('csau_sos'), 1, card.ability.extra.prob) then
         return {
             x_mult = card.ability.extra.x_mult,
             card = card
         }
     end
-    local bad_context = context.repetition or context.individual or context.blueprint
-    if context.after and not card.ability.destroyed and card.ability.activated and not bad_context then
-        card.ability.extra.uses = card.ability.extra.uses+1
+
+    if context.after and not card.ability.destroyed and card.ability.activated then
+        card.ability.extra.uses = card.ability.extra.uses + 1
         if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
             G.FUNCS.destroy_tape(card)
             card.ability.destroyed = true

--- a/items/vhs/topslots.lua
+++ b/items/vhs/topslots.lua
@@ -9,7 +9,7 @@ local consumInfo = {
         extra = {
             max_initial_money = 20,
 
-            winnings = nil,
+            winnings = 0,
             conv_money = 1,
             conv_score = 20,
             prob_double = 6,
@@ -31,43 +31,59 @@ local consumInfo = {
 function consumInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.chvsau } }
-    return { vars = { card.ability.extra.conv_money, card.ability.extra.conv_score, card.ability.extra.max_initial_money, G.GAME.probabilities.normal, card.ability.extra.prob_double, card.ability.extra.prob_triple, card.ability.extra.runtime-card.ability.extra.uses } }
+
+    local num, dom1 = SMODS.get_probability_vars(card, 1, card.ability.extra.prob_double)
+    local _, dom2 = SMODS.get_probability_vars(card, 1, card.ability.extra.prob_triple)
+    
+    return { 
+        vars = {
+            card.ability.extra.conv_money,
+            card.ability.extra.conv_score,
+            card.ability.extra.max_initial_money,
+            num, dom1, dom2,
+            card.ability.extra.runtime-card.ability.extra.uses
+        }
+    }
 end
 
 function consumInfo.calculate(self, card, context)
-    local bad_context = context.repetition or context.individual or context.blueprint
-    if card.ability.activated and context.end_of_round and not card.debuff and not bad_context then
-        if G.GAME.chips > G.GAME.blind.chips then
-            local percent = ((G.GAME.chips - G.GAME.blind.chips) / G.GAME.blind.chips) * 100
-            local money = math.floor(percent / card.ability.extra.conv_score) + card.ability.extra.conv_money
-            if to_big(money) > to_big(card.ability.extra.max_initial_money) then
-                money = card.ability.extra.max_initial_money
-            end
-            local doubled, tripled = false, false
-            if pseudorandom('READYOURMACHINES') < G.GAME.probabilities.normal / card.ability.extra.prob_double then
-                money = money * card.ability.extra.double
-                doubled = true
-            end
-            if pseudorandom('NOCONTROLOVERTHAT') < G.GAME.probabilities.normal / card.ability.extra.prob_triple then
-                money = money * card.ability.extra.triple
-                tripled = true
-            end
-            card.ability.extra.winnings = money
-            card.ability.extra.uses = card.ability.extra.uses + 1
-            if doubled or tripled then
-                return {
-                    message = localize((doubled and tripled and 'k_ts_wild') or (doubled and not tripled and 'k_ts_doubled') or (tripled and not doubled and 'k_ts_tripled')),
-                    card = card
-                }
-            end
+    if card.debuff or context.blueprint then return end
+
+    if card.ability.activated and context.end_of_round and not context.repetition and not context.individual and G.GAME.chips > G.GAME.blind.chips then
+        local percent = ((G.GAME.chips - G.GAME.blind.chips) / G.GAME.blind.chips) * 100
+        local money = math.floor(percent / card.ability.extra.conv_score) + card.ability.extra.conv_money
+        if to_big(money) > to_big(card.ability.extra.max_initial_money) then
+            money = card.ability.extra.max_initial_money
+        end
+
+        local doubled, tripled = false, false
+        if SMODS.pseudorandom_probability(card, pseudoseed('csau_topslots_double'), 1, card.ability.extra.prob_double) then
+            money = money * card.ability.extra.double
+            doubled = true
+        end
+        
+        if SMODS.pseudorandom_probability(card, pseudoseed('csau_topslots_triple'), 1, card.ability.extra.prob_triple) then
+            money = money * card.ability.extra.triple
+            tripled = true
+        end
+
+        card.ability.extra.winnings = money
+        card.ability.extra.uses = card.ability.extra.uses + 1
+        if doubled or tripled then
+            return {
+                message = localize((doubled and tripled and 'k_ts_wild') or (doubled and not tripled and 'k_ts_doubled') or (tripled and not doubled and 'k_ts_tripled')),
+                card = card
+            }
         end
     end
+
     if context.starting_shop and not context.blueprint then
         if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
             G.FUNCS.destroy_tape(card)
             card.ability.destroyed = true
         end
     end
+
     if card.ability.activated and context.game_over then
         check_for_unlock({ type = "the_scot" })
     end

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -427,8 +427,6 @@ return {
 			k_aced = "Aced!",
 			k_twoed = "Twoed!",
 			k_twoed_aced = "Two-Aced!",
-			k_plus_one = "+1 ",
-			k_plus_one_card = "+1 Card",
 			k_plus_two = "+2 ",
 			k_child = "Child",
 			k_plus_judge = "+1 Judgement",
@@ -554,6 +552,7 @@ return {
 		v_dictionary = {
 			a_plus_discard = "+#1# Discard",
 			a_plus_hand = "+#1# Hand",
+			a_plus_card = "+#1# Cards",
 			a_red = "#1#!!!",
 			a_duane = "#1#!",
 			a_chance = "#1# in #2#",
@@ -745,7 +744,7 @@ return {
 			ach_csau_high_feature = "Have IT'S A FEATURE pay out $50 or more",
 			ach_csau_high_muppet = "Get Movin' Right Along to X4 Mult",
 			ach_csau_high_supper = "Proc WAAUGGHGHHHHGHH 10 times in one hand",
-			ach_csau_high_horse = "Put Gold Seals on 5 Gold Cards at once with Devil Story",
+			ach_csau_high_horse = "Play a hand of 5 scoring Gold Cards while Devil Story is playing",
 			ach_csau_play_flushfib = "Play a Flush Fibonacci",
 			ach_csau_play_flushblackjack = "Play a Flush Blackjack",
 			ach_csau_preserve_gros = "Use Scourge of Pantsylvania to preserve Gros Michel",
@@ -760,7 +759,7 @@ return {
 			ach_csau_activate_quixotic = "Use a Quixotic Card",
 			ach_csau_activate_roche = "Receive a gift from Motorcyclist Joker",
 			ach_csau_fuckingkill_jimbo = "Fucking kill Jimbo",
-			ach_csau_high_one = "Have 2 High Card enhancing Jokers in your Joker slots",
+			ach_csau_high_one = "Have 2 unique High Card enhancing Jokers in your Joker slots",
 			ach_csau_miracle_inherit = "Use Miracle of Life to create a child that inherits an Enhancement, Seal, or Edition",
 			ach_csau_reno_colors = "Set the title screen colors to black and red",
 			ach_csau_skin_vineshroom = "Customize your deck to use the Classic Vineshroom for the Ace of Clubs",
@@ -1488,8 +1487,8 @@ return {
 			j_csau_maskedjoker = {
 				name = "Masked Joker",
 				text = {
-					"If played hand is all",
-					"{C:attention}Steel Cards{}, each gives",
+					"If played hand is all {C:attention}Steel Cards{},",
+					"each {C:attention}scoring{} card gives",
 					"{C:chips}+#1#{} Chips and {C:mult}+#2#{} Mult",
 				},
 			},
@@ -1734,8 +1733,8 @@ return {
 			j_csau_miracle = {
 				name = "Miracle of Life",
 				text = {
-                    "{C:green}#1# in 2{} chance to add",
-                    "a new {C:attention}playing card to",
+                    "{C:green}#1# in #2#{} chance to add",
+                    "a new {C:attention}playing card{} to",
                     "your hand for every",
                     "{C:attention}Pair{} in played hand",
                 },
@@ -1844,8 +1843,8 @@ return {
 				text = {
 					"If {C:attention}first hand{} of round contains",
 					"only {C:attention}face cards{}, earn {C:money}$#1#{} and",
-					"{C:green}#2# in 3{} chance to destroy",
-					"{C:attention}#3#{} random card in {C:attention}played hand{}"
+					"{C:green}#2# in #3#{} chance to destroy",
+					"{C:attention}#4#{} random card in {C:attention}played hand{}"
 				},
 			},
 			j_csau_muppet = {
@@ -2298,8 +2297,8 @@ return {
 			j_csau_plaguewalker = {
 				name = "Plaguewalker",
 				text = {
-					"{C:attention}Glass Cards{} have {X:mult,C:white} X3 {} Mult",
-					"and {C:green}#1# in 2{} chance to break"
+					"{C:attention}Glass Cards{} have {X:mult,C:white}X#1#{} Mult",
+					"and {C:green}#2# in #3#{} chance to break"
 				},
 			},
 			j_csau_skeletor = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -2511,10 +2511,10 @@ return {
 			j_csau_junka = {
 				name = "Black Spine Junka",
 				text = {
-					"Gains {X:mult,C:white} X#1# {} Mult, {C:green}+#2#{} chance, and has a",
-					"{C:green}#3# in #4#{} chance to {C:red}self destruct{}",
+					"Gains {X:mult,C:white}X#1#{} Mult, {C:green}+#2#{} chance, and has a",
+					"{C:green}#3# in #4#{} chance to {C:red,E:1}self destruct{}",
 					"each time a {C:vhs}VHS Tape{} finishes",
-					"{C:inactive}(Currently {}{X:mult,C:white} X#5# {}{C:inactive} Mult{}{C:inactive}){}",
+					"{C:inactive}(Currently {}{X:mult,C:white X#5#{}{C:inactive} Mult{}{C:inactive}){}",
 				},
 				unlock = {
 					"Discover {E:1,C:attention}#1#{} {E:1,C:vhs}VHS Tapes",
@@ -2592,7 +2592,7 @@ return {
 			j_csau_expiredmeds = {
 				name = "Expired Medicine",
 				text = {
-					"When {C:attention}sold{} reappears in the",
+					"When {C:attention}sold{}, reappears in the",
 					"next shop with {C:chips}+#1#{} Chips",
 					"{C:green}#2# in #3#{} chance to {C:attention}reset{} instead",
 					"{C:inactive}(Currently {}{C:chips}+#4#{}{C:inactive} Chips{}{C:inactive}){}",
@@ -3071,8 +3071,8 @@ return {
 			c_csau_vento_gold = {
 				name = "Gold Experience",
 				text = {
-					"{C:green}#1# in #2#{} chance for scored {V:1}#3#{}",
-					"to become {C:attention}Gold Cards{}",
+					"{C:green}#1# in #2#{} chance for scored",
+					"{V:1}#3#{} to become {C:attention}Gold Cards{}",
 					"{s:0.1} {}",
 					"{C:stand}Evolves{} after using {C:tarot}The Arrow{}",
 				},
@@ -3080,9 +3080,8 @@ return {
 			c_csau_vento_gold_requiem = {
 				name = "Gold Experience Requiem",
 				text = {
-					"{C:green}#1# in #2#{} chance to {C:planet}level up{} played {C:attention}poker hand{}",
-					"{s:0.1} {}",
-					"Each scoring {C:attention}Gold Card{} increases odds by {C:green}#3#{}",
+					"{C:green}#1# in #2#{} chance per scoring {C:attention}Gold Card{}",
+					"to {C:planet}level up{} played {C:attention}poker hand{}",
 				},
 			},
 			c_csau_vento_moody = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1574,7 +1574,7 @@ return {
 			j_csau_pivot = {
 				name = "Pivyot Joker",
 				text = {
-					"{C:green}#1# in 3{} chance to upgrade",
+					"{C:green}#1# in #2#{} chance to upgrade",
 					"level of played {C:attention}High Card{}",
 				},
 			},

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1801,8 +1801,8 @@ return {
 			j_csau_red = {
 				name = "Why Are You Red?",
 				text = {
-					"{C:green}#1# in #2#{} chance to",
-					"convert all scored cards to {V:1}#3#{}",
+					"{C:green}#1# in #2#{} chance to convert",
+					"all scored cards to {V:1}#3#{}",
 					"{C:attention}after scoring{}",
 				},
 			},


### PR DESCRIPTION
# Achievement Fixes
- Fixed achievements procs for **Did Sephiroth... Do This?**, ***Chain Attack OST Plays***, **All You Need Is One**, and **Cardsauce++, 
- **HORSE!!:** has been changed to account for its new ability ("Put Gold Seals on 5 Gold Cards at once with Devil Story"-> "Play a hand of 5 scoring Gold Cards while Devil Story is playing")
- **16-Hit Combo** now requires a full hand of 5 steel cards as expected, similar to **Ultimate Choomera**

# Gameplay Changes
- Devil Story running time increased (3 cards -> 10 cards)
- Gold Experience Requiem's ability changed (#gold cards in 5 chance to level up played hand -> 1 in 5 chance per scoring gold card to level up played hand individually)
- Blowzo Brothers, Expired Meds, The Miracle of Life, and Plaguewalker rewritten internally for conciseness and stability
- Multiple items updated to use SMODS's new probability functions
  - The Tray
  - The Hog
  - Varg Deck
  - Varg Sleeve
  - 7 Funny Story
  - Agga
  - Beginner's Luck
  - Black Spine Junka
  - Blowzo Brothers
  - Business Trading Card
  - Depressed Brother
  - Emmanuel Blast
  - IT'S A FEATURE
  - Live Dangerously
  - Miracle of Life
  - Monkey Mondays
  - Pivyot
  - Protogent Antivirus
  - Sprunk
  - THE FLUSHER
  - Why Are You Red?
  - Gold Experience
  - Gold Experience Requiem
  - Alien Private Eye
  - Nukie
  - SOS
  - Top Slots
- G.FUNCS.csau_add_chance deprecated and removed due to being superseded by native SMODS features
- Meteor and Metallica now use Quantum Enhancements rather than manually replicating enhancement effects