### PR TITLE
Bugfixing and 2 Kings Rework

### DIFF
--- a/includes/hooks/UI_definitions.lua
+++ b/includes/hooks/UI_definitions.lua
@@ -219,16 +219,6 @@ function create_shop_card_ui(card, type, area)
 							{n=G.UIT.O, config={object = DynaText({string = {{prefix = localize('$'), ref_table = card, ref_value = 'cost'}}, colours = {G.C.MONEY},shadow = true, silent = true, bump = true, pop_in = 0, scale = 0.5})}},
 						}}
 					}}
-				local t2 = card.ability.set == 'Voucher' and {
-					n=G.UIT.ROOT, config = {ref_table = card, minw = 1.1, maxw = 1.3, padding = 0.1, align = 'bm', colour = G.C.GREEN, shadow = true, r = 0.08, minh = 0.94, func = 'can_redeem', one_press = true, button = 'redeem_from_shop', hover = true}, nodes={
-						{n=G.UIT.T, config={text = localize('b_redeem'),colour = G.C.WHITE, scale = 0.4}}
-					}} or card.ability.set == 'Booster' and {
-					n=G.UIT.ROOT, config = {ref_table = card, minw = 1.1, maxw = 1.3, padding = 0.1, align = 'bm', colour = G.C.GREEN, shadow = true, r = 0.08, minh = 0.94, func = 'can_open', one_press = true, button = 'open_booster', hover = true}, nodes={
-						{n=G.UIT.T, config={text = localize('b_open'),colour = G.C.WHITE, scale = 0.5}}
-					}} or {
-					n=G.UIT.ROOT, config = {ref_table = card, minw = 1.1, maxw = 1.3, padding = 0.1, align = 'bm', colour = G.C.GOLD, shadow = true, r = 0.08, minh = 0.94, func = 'can_buy', one_press = true, button = 'buy_from_shop', hover = true}, nodes={
-						{n=G.UIT.T, config={text = localize('b_buy'),colour = G.C.WHITE, scale = 0.5}}
-					}}
 
 				local function get_t3(align, ghost, invisible)
 					ghost = ghost or false
@@ -273,16 +263,14 @@ function create_shop_card_ui(card, type, area)
 				center_nodes[#center_nodes+1] = buy
 				local center_column = {n=G.UIT.C, config={align = 'bm', minh=(((2.4*47/41)+0.3)+1.04+(card.ability.set == 'Booster' and 0.8 or 0))*scale}, nodes = center_nodes}
 
-
-
 				local left_nodes = {}
 				left_nodes[#left_nodes+1] = get_t3('cl', true, true)
 				local left_column = {n=G.UIT.C, config={align = 'cm'}, nodes = left_nodes}
 
 				local right_nodes = {}
-				right_nodes[#right_nodes+1] = {n=G.UIT.R, config = {id = 'morshu_save', ref_table = card, minh = 0.8, padding = 0.1, align = 'cr', colour = G.C.PURPLE, shadow = true, r = 0.08, minw = 1.2, one_press = true, button = 'save_to_morshu', hover = true, focus_args = {type = 'none'}}, nodes={
+				right_nodes[#right_nodes+1] = {n=G.UIT.R, config = {id = 'morshu_save', ref_table = card, minh = 0.8, padding = 0.1, align = 'cr', colour = G.C.PURPLE, shadow = true, r = 0.08, minw = 1.5, one_press = true, button = 'save_to_morshu', hover = true, focus_args = {type = 'none'}}, nodes={
 					{n=G.UIT.C, config = {align = 'cm', maxw = 1}, nodes={
-						{n=G.UIT.T, config={text = localize('b_save'),colour = G.C.WHITE, scale = 0.4}}
+						{n=G.UIT.T, config={text = localize('b_save'),colour = G.C.WHITE, scale = 0.5}}
 					}}
 				}}
 				if card.ability.consumeable and card:can_use_consumeable(true, true) then
@@ -361,6 +349,7 @@ function create_shop_card_ui(card, type, area)
 			end)
 		}))
 	else
+		sendDebugMessage('default shop card UI')
 		cscui_ref(card, type, area)
 	end
 end

--- a/includes/shaders.lua
+++ b/includes/shaders.lua
@@ -402,3 +402,32 @@ SMODS.DrawStep {
     end,
     conditions = { vortex = false, facing = 'front' },
 }
+
+
+
+
+
+---------------------------
+--------------------------- 2 Kings VFX
+---------------------------
+
+local old_back_ds = SMODS.DrawSteps.back.func
+SMODS.DrawStep:take_ownership('back', {
+    func = function(self, layer)
+        if not self.csau_2kings_rank then
+            return old_back_ds(self, layer)
+        end
+
+        local overlay = G.C.WHITE
+        if self.csau_2kings_rank > 3 then
+            self.back_overlay = self.back_overlay or {}
+            self.back_overlay[1] = 0.5 + ((self.csau_2kings_total - self.csau_2kings_rank)%7)/50
+            self.back_overlay[2] = 0.5 + ((self.csau_2kings_total - self.csau_2kings_rank)%7)/50
+            self.back_overlay[3] = 0.5 + ((self.csau_2kings_total - self.csau_2kings_rank)%7)/50
+            self.back_overlay[4] = 1
+            overlay = self.back_overlay
+        end
+
+        self.children.back:draw(overlay)
+    end
+})

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -23,7 +23,7 @@ local function dynamic_badges(info)
 			return scale_fac
 		end
 		local scale_fac = {}
-		local min_scale_fac = 1
+		local min_scale_fac = 0.4
 		local strings = { "Cardsauce" }
 		local badge_colour = HEX('32A852')
 		local text_colour = G.C.WHITE
@@ -74,7 +74,7 @@ local function dynamic_badges(info)
 						align = "cm",
 						colour = badge_colour,
 						r = 0.1,
-						minw = 2 / min_scale_fac,
+						minw = 1 / min_scale_fac,
 						minh = 0.36,
 						emboss = 0.05,
 						padding = 0.03 * 0.9,

--- a/items/challenges/nmbb.lua
+++ b/items/challenges/nmbb.lua
@@ -10,6 +10,11 @@ local chalInfo = {
     jokers = {
         { id = 'j_csau_blackjack', eternal = true}
     },
+    restrictions = {
+        banned_other = {
+            id = 'bl_csau_mochamike', type = 'blind',
+        }
+    },
     unlocked = function(self)
         return G.FUNCS.discovery_check({ mode = 'key', key = 'j_csau_blackjack' })
     end

--- a/items/jokers/genres.lua
+++ b/items/jokers/genres.lua
@@ -1,14 +1,14 @@
 local jokerInfo = {
     name = "Battle of the Genres",
     config = {
-        debuffed = false,
         extra = {
             h_mod = 1,
-        }
+        },
+        added_h_size = 0,
     },
     rarity = 2,
     cost = 6,
-    blueprint_compat = true,
+    blueprint_compat = false,
     eternal_compat = true,
     perishable_compat = true,
     streamer = "othervinny",
@@ -31,35 +31,37 @@ function jokerInfo.add_to_deck(self, card)
     local count = G.FUNCS.get_vhs_count()
     if count > 0 then
         G.hand:change_size(card.ability.extra.h_mod * count)
+        card.ability.added_h_size = card.ability.added_h_size + card.ability.extra.h_mod * count
     end
 end
 
 function jokerInfo.remove_from_deck(self, card)
-    local count = G.FUNCS.get_vhs_count()
-    if count > 0 then
-        G.hand:change_size(-(card.ability.extra.h_mod * count))
+    if card.ability.added_h_size > 0 then
+        G.hand:change_size(-card.ability.added_h_size)
+        card.ability.added_h_size = 0
     end
 end
 
 function jokerInfo.calculate(self, card, context)
-    if not context.blueprint and not card.debuff then
-        if context.vhs_death then
-            G.hand:change_size(-card.ability.extra.h_mod)
-            card:juice_up()
-        end
-        if context.buying_card then
-            if context.card.ability.set == "VHS" then
-                G.hand:change_size(card.ability.extra.h_mod)
-                card:juice_up()
-            end
-        end
-        if context.selling_card then
-            if context.card.ability.set == "VHS" then
-                card:juice_up()
-            end
-        end
+    if context.blueprint or card.debuff then return end
+
+    if context.vhs_death and card.ability.added_h_size > card.ability.extra.h_mod then
+        G.hand:change_size(-card.ability.extra.h_mod)
+        card.ability.added_h_size = card.ability.added_h_size - card.ability.extra.h_mod
+        card:juice_up()
+    end
+
+    if context.card_added and context.card.ability.set == "VHS" then
+        G.hand:change_size(card.ability.extra.h_mod)
+        card.ability.added_h_size = card.ability.added_h_size + card.ability.extra.h_mod
+        card:juice_up()
+    end
+
+    if context.selling_card and context.card.ability.set == "VHS" and card.ability.added_h_size > card.ability.extra.h_mod then
+        G.hand:change_size(-card.ability.extra.h_mod)
+        card.ability.added_h_size = card.ability.added_h_size - card.ability.extra.h_mod
+        card:juice_up()
     end
 end
 
 return jokerInfo
-	

--- a/items/jokers/kings.lua
+++ b/items/jokers/kings.lua
@@ -2,17 +2,55 @@ local jokerInfo = {
     name = '2 Kings 2:23-24',
     config = {
         extra = {
-            cards = {}
+            king_cards = {},
+            max_cards = 42
         },
     },
     rarity = 3,
     cost = 8,
     unlocked = false,
-    blueprint_compat = true,
+    blueprint_compat = false,
     eternal_compat = true,
     perishable_compat = true,
     streamer = "joel",
 }
+
+local function create_kings_area(card, max_cards)
+    local card_num = math.min(#G.deck.cards, max_cards) 
+    G['csau_kings_remove_'..card.ID] = CardArea(card.T.x, card.T.y, G.CARD_W, G.CARD_H, {
+        card_limit = card_num,
+        type = 'kings_deck',
+    })
+
+	G['csau_kings_remove_'..card.ID].states.collide.can = false
+	G['csau_kings_remove_'..card.ID].states.drag.can = false
+    G['csau_kings_remove_'..card.ID].ARGS.invisible_area_types = {
+        discard = 1,
+        voucher = 1,
+        play = 1,
+        consumeable = 1,
+        title = 1,
+        title_2 = 1,
+        kings_deck = 1,
+    }
+
+    local new_uibox = UIBox{
+        definition = 
+            {n=G.UIT.ROOT, config = {align = 'cm', colour = G.C.CLEAR}, nodes={
+                {n=G.UIT.R, config={minw = G['csau_kings_remove_'..card.ID].T.w, minh = G['csau_kings_remove_'..card.ID].T.h, align = "cm", padding = 0.1, mid = true, r = 0.1, ref_table = G['csau_kings_remove_'..card.ID]}},
+                {n=G.UIT.R, config={align = 'cr', padding = 0.03, no_fill = true}, nodes={
+                    {n=G.UIT.B, config={w = 0.1,h=0.1}},
+                    {n=G.UIT.T, config={ref_table = G['csau_kings_remove_'..card.ID].config, ref_value = 'card_count', scale = 0.4, colour = G.C.WHITE}},
+                    {n=G.UIT.B, config={w = 0.1,h=0.1}}
+                }}
+            }},
+        config = { align = 'cm', offset = {x=0,y=0}, major = G['csau_kings_remove_'..card.ID], parent = G['csau_kings_remove_'..card.ID]}
+    }
+    new_uibox.states.visible = true
+    G['csau_kings_remove_'..card.ID].children.area_uibox = new_uibox
+
+    return G['csau_kings_remove_'..card.ID]
+end
 
 function jokerInfo.check_for_unlock(self, args)
     if args.type == "unlock_kings" then
@@ -22,171 +60,215 @@ end
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.winterg } }
-    return { vars = { card.ability.extra.x_mult } }
 end
 
-local draw_from_deck_to_destroy = function(e)
-    for i=1, e do
-        draw_card(G.deck,G.csau_destroy, i*100/e,'up', true)
-    end
-end
+function jokerInfo.load(self, card, card_table, other_card)
+    if #card_table.ability.extra.king_cards > 0 then
+        local kings_area = create_kings_area(card, card_table.ability.extra.max_cards)
 
-local draw_from_destroy_to_deck = function(e)
-    for i=1, e do
-        draw_card(G.csau_destroy,G.deck, i*100/e,'up', true)
-    end
-end
-
-local function findCard(suit, id)
-    for k, v in pairs(G.P_CARDS) do
-        local cardId = tonumber(v.value) or
-            (v.value == "Jack" and 11) or
-            (v.value == "Queen" and 12) or
-            (v.value == "King" and 13) or
-            (v.value == "Ace" and 14)
-
-        if v.suit == suit and cardId == id then
-            return k
-        end
-    end
-    return nil
-end
-
-local function getEnhancement(name)
-    if name == "Base" then
-        return G.P_CENTERS.c_base
-    else
-        for k, v in pairs(G.P_CENTERS) do
-            if v.set == "Enhanced" then
-                if v.effect == name or v.label == name then
-                    return v
-                end
-            end
+        for _, v in ipairs(card_table.ability.extra.king_cards) do
+            local new_card = Card(
+                kings_area.T.x,
+                kings_area.T.y,
+                G.CARD_W,
+                G.CARD_H,
+                G.P_CARDS[v.card_key],
+                G.P_CENTERS[v.center_key],
+                {
+                    bypass_discovery_center = true,
+                    bypass_discovery_ui = true
+                })
+            new_card:set_edition(v.edition, true, true)
+            new_card:set_seal(v.seal, true, true)
+            kings_area:emplace(new_card, 'front', true)
         end
     end
 end
 
-function jokerInfo.add_to_deck(self, card)
-    if G.GAME.buttons then G.GAME.buttons:remove(); G.GAME.buttons = nil end
-    local yOffset = -4
+function jokerInfo.add_to_deck(self, card, from_debuff)
+    if from_debuff or not G.playing_cards or #G.deck.cards <= 0 then return end
+
+    if G.GAME.buttons then
+        G.GAME.buttons:remove();
+        G.GAME.buttons = nil
+    end
+
+    G.CONTROLLER.locks.csau_2kings = true
     if G.shop and not G.shop.REMOVED then
         G.shop.alignment.offset.y = G.ROOM.T.y+11
-    else
-        yOffset = -5
     end
 
-    G.csau_destroy = CardArea(
-            G.TILE_W - G.hand.T.w - 2.65,
-            G.TILE_H - G.hand.T.h + yOffset,
-            6*G.CARD_W,
-            0.95*G.CARD_H,
-            {card_limit = 42,
-             card_w = 0.6*G.CARD_W, type = 'title', highlight_limit = 0})
+    local kings_area = create_kings_area(card, card.ability.extra.max_cards)
 
     G.E_MANAGER:add_event(Event({
         trigger = 'immediate',
         func = function()
-            G.E_MANAGER:add_event(Event({
-                trigger = 'immediate',
-                func = function()
-                    draw_from_deck_to_destroy(42)
+            for i=1, kings_area.config.card_limit do
+                G.E_MANAGER:add_event(Event({
+                    trigger = 'before',
+                    delay = 0.06,
+                    func = function()
+                        local drawn_card = G.deck:remove_card()
+                        drawn_card:remove_from_deck()
+                        G.deck.config.card_limit =  G.deck.config.card_limit - 1
+                        kings_area:emplace(drawn_card,'front', true)
 
-                    G.E_MANAGER:add_event(Event({
-                        trigger = 'after',
-                        delay = 0.5,
-                        func = function()
-                            for i = 1, #G.csau_destroy.cards do
-                                local _card = G.csau_destroy.cards[i]
-                                local edition = _card.config.center.key
-                                local id = _card:get_id()
-                                local suit = _card.base.suit
-                                local key = findCard(suit, id)
-                                table.insert(
-                                    card.ability.extra.cards,
-                                    {
-                                        key,
-                                        _card.ability.effect,
-                                        _card.seal or nil,
-                                        edition
-                                    }
-                                )
-                                if _card.ability.name == 'Glass Card' then
-                                    _card:shatter()
-                                else
-                                    _card:start_dissolve(nil, i == #G.csau_destroy.cards)
-                                end
+                        -- reassign playing cards
+                        for k, v in ipairs(G.playing_cards) do
+                            if v == drawn_card then
+                                table.remove(G.playing_cards, k)
+                                break
                             end
-                            return true end }))
+                        end
 
-                    G.E_MANAGER:add_event(Event({
-                        trigger = 'after',
-                        delay = 1,
-                        func = function()
-                            if G.shop and not G.shop.REMOVED then G.shop.alignment.offset.y = -5.3 end
-                            return true end }))
+                        for k, v in ipairs(G.playing_cards) do
+                            v.playing_card = k
+                        end
+
+                        G.playing_card = #G.playing_cards
+
+                        table.insert(card.ability.extra.king_cards, {
+                            card_key = drawn_card.config.card_key,
+                            center_key = drawn_card.config.center.key,
+                            seal = drawn_card.seal,
+                            edition = drawn_card.edition and drawn_card.edition.type or nil
+                        })
+                        drawn_card.children.back.states.visible = true
+                        drawn_card.states.collide.can = false
+                        drawn_card.states.drag.can = false
+
+                        G.VIBRATION = G.VIBRATION + 0.35
+                        card:juice_up()
+                        play_sound('card1', 0.85 + (i*100/kings_area.config.card_limit)*0.2/100, 0.6)
+                        return true
+                    end
+                }))
+            end
+
+            G.E_MANAGER:add_event(Event({
+                trigger = 'after',
+                delay = 1,
+                func = function()
+                    if G.shop and not G.shop.REMOVED then G.shop.alignment.offset.y = -5.3 end
+                    G.CONTROLLER.locks.csau_2kings = nil
                     return true
                 end
             }))
+
             return true
         end
     }))
 end
 
-function jokerInfo.remove_from_deck(self, card)
-    if G.playing_cards ~= nil and to_big(#card.ability.extra.cards) > to_big(0) then
-        if G.GAME.buttons then G.GAME.buttons:remove(); G.GAME.buttons = nil end
-        local yOffset = -4
-        if G.shop and not G.shop.REMOVED then
-            G.shop.alignment.offset.y = G.ROOM.T.y+11
-        else
-            yOffset = -5
+function jokerInfo.update(self, card, dt)
+    if G['csau_kings_remove_'..card.ID] then
+        local kings_area = G['csau_kings_remove_'..card.ID]
+        kings_area.T.x = card.T.x
+        kings_area.T.y = card.T.y + 0.092
+        kings_area.VT.x = card.VT.x
+        kings_area.VT.y = card.VT.y + 0.092
+
+        local deck_height = 0.15/52
+        for i, removed_card in ipairs(kings_area.cards) do
+            removed_card.T.x = kings_area.T.x + 0.5*(kings_area.T.w - removed_card.T.w) + kings_area.shadow_parrallax.x*deck_height*(#kings_area.cards - i) + 0.9*kings_area.shuffle_amt*(1 - i*0.01)*(i%2 == 1 and 1 or -0)
+            removed_card.T.y = kings_area.T.y + 0.5*(kings_area.T.h - removed_card.T.h) + kings_area.shadow_parrallax.y*deck_height*(#kings_area.cards - i)
+            removed_card.T.r = 0 + 0.3*kings_area.shuffle_amt*(1 + i*0.05)*(i%2 == 1 and 1 or -0)
+            removed_card.T.x = removed_card.T.x + removed_card.shadow_parrallax.x/30
         end
+    end
+end
 
-        G.csau_destroy = CardArea(
-            G.TILE_W - G.hand.T.w - 2.65,
-            G.TILE_H - G.hand.T.h + yOffset,
-            6*G.CARD_W,
-            0.95*G.CARD_H,
-            {card_limit = 42,
-             card_w = 0.6*G.CARD_W, type = 'title', highlight_limit = 0})
+function jokerInfo.draw(self, card, layer)
+    if G['csau_kings_remove_'..card.ID] then
+        local kings_area = G['csau_kings_remove_'..card.ID]
+        kings_area.children.area_uibox:draw()
+        for i = #kings_area.cards, 1, -1 do
+            local kings_card = kings_area.cards[i]
+            if i == 1 or i%9 == 0 or i == #kings_area.cards or math.abs(kings_card.VT.x - kings_area.T.x) > 1 or math.abs(kings_card.VT.y - kings_area.T.y) > 1 then
+                local overlay = G.C.WHITE
+                if kings_card.rank > 3 then
+                    kings_card.back_overlay = kings_card.back_overlay or {}
+                    kings_card.back_overlay[1] = 0.5 + ((#kings_area.cards - kings_card.rank)%7)/50
+                    kings_card.back_overlay[2] = 0.5 + ((#kings_area.cards - kings_card.rank)%7)/50
+                    kings_card.back_overlay[3] = 0.5 + ((#kings_area.cards - kings_card.rank)%7)/50
+                    kings_card.back_overlay[4] = 1
+                    overlay = kings_card.back_overlay
+                end
 
-        for i, v in ipairs(card.ability.extra.cards) do
-            local key = v[1]
-            local effect = v[2]
-            local center = getEnhancement(effect)
-            local seal = v[3]
-            local edition = v[4]
-
-            local _card = create_playing_card({front = G.P_CARDS[key], center = center}, G.csau_destroy, nil, nil, {G.C.SECONDARY_SET.Enhanced})
-            _card:set_ability(center, true, nil)
-            if seal then _card:set_seal(seal, true) end
-            if edition == "foil" then
-                _card:set_edition({foil = true}, true, true)
-            elseif edition == "holo" then
-                _card:set_edition({holo = true}, true, true)
-            elseif edition == "polychrome" then
-                _card:set_edition({polychrome = true}, true, true)
+                kings_card.children.back:draw(overlay)
             end
         end
+
+        card.children.center:draw_shader('dissolve')
+    end
+end
+
+function jokerInfo.remove_from_deck(self, card, from_debuff)
+    if from_debuff or not G.playing_cards then return end
+
+    if G['csau_kings_remove_'..card.ID] then
+        local kings_area = G['csau_kings_remove_'..card.ID]
+        if G.GAME.buttons then
+            G.GAME.buttons:remove();
+            G.GAME.buttons = nil
+        end
+
+        G.CONTROLLER.locks.csau_2kings = true
+
+        if G.shop and not G.shop.REMOVED then
+            G.shop.alignment.offset.y = G.ROOM.T.y+11
+        end
+        
+        local remove_cards = {}
+        local total_kings_cards = #kings_area.cards
+        for i=1, total_kings_cards do
+            local drawn_card = kings_area:remove_card()
+            drawn_card.no_shadow = true
+            table.insert(remove_cards, 1, drawn_card)
+            drawn_card.csau_2kings_rank = #kings_area.cards + 1
+            drawn_card.csau_2kings_total = total_kings_cards
+        end
+        
         G.E_MANAGER:add_event(Event({
-            trigger = 'after',
-            delay = 0.25,
+            trigger = 'immediate',
             func = function()
+                for i=1, #remove_cards do
+                    G.E_MANAGER:add_event(Event({
+                        trigger = 'before',
+                        delay = 0.06,
+                        func = function()
+                            local drawn_card = table.remove(remove_cards, 1)
+                            drawn_card.no_shadow = false
+                            drawn_card.csau_2kings_rank = nil
+                            drawn_card.csau_2kings_total = nil
+                            G.deck:emplace(drawn_card, nil, true)
+                            G.deck:sort()
+
+                            G.playing_card = (G.playing_card and G.playing_card + 1) or 1
+                            drawn_card.playing_card = G.playing_card
+                            table.insert(G.playing_cards, drawn_card)
+                            G.deck.config.card_limit = G.deck.config.card_limit + 1
+
+                            G.VIBRATION = G.VIBRATION + 0.35
+                            card:juice_up()
+                            play_sound('card1', 0.85 + (1-(i*100/kings_area.config.card_limit))*0.2/100, 0.6)
+                            return true
+                        end
+                    }))
+                end
+
                 G.E_MANAGER:add_event(Event({
-                    trigger = 'immediate',
+                    trigger = 'after',
+                    delay = 1,
                     func = function()
-                        draw_from_destroy_to_deck(#G.csau_destroy.cards)
-                        G.E_MANAGER:add_event(Event({
-                            trigger = 'after',
-                            delay = 1,
-                            func = function()
-                                if G.shop and not G.shop.REMOVED then G.shop.alignment.offset.y = -5.3 end
-                                return true
-                            end
-                        }))
+                        if G.shop and not G.shop.REMOVED then G.shop.alignment.offset.y = -5.3 end
+                        card.ability.extra.king_cards = {}
+                        kings_area:remove()
+                        G.CONTROLLER.locks.csau_2kings = nil
                         return true
                     end
                 }))
+
                 return true
             end
         }))

--- a/items/jokers/skeletonmetal.lua
+++ b/items/jokers/skeletonmetal.lua
@@ -18,7 +18,9 @@ function jokerInfo.loc_vars(self, info_queue, card)
 end
 
 function jokerInfo.calculate(self, card, context)
-    if context.before and to_big(G.GAME.current_round.hands_left) == to_big(0) and not context.blueprint and not card.debuff then
+    if card.debuff then return end
+
+    if context.before and to_big(G.GAME.current_round.hands_left) == to_big(0) then
         local cards = {}
         for i=1, card.ability.extra do
             local _card = create_playing_card({
@@ -27,9 +29,13 @@ function jokerInfo.calculate(self, card, context)
             G.GAME.blind:debuff_card(_card)
             cards[#cards+1] = _card
         end
+
         playing_card_joker_effects({cards})
+
         G.hand:sort()
-        if context.blueprint_card then context.blueprint_card:juice_up() else card:juice_up() end
+
+        local juice_card = context.blueprint_card or card
+        juice_card:juice_up()
     end
 end
 

--- a/items/jokers/sts.lua
+++ b/items/jokers/sts.lua
@@ -92,15 +92,17 @@ end
 
 function jokerInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
-    return { vars = {card.ability.diamonds.mult_mod, card.ability.diamonds.mult, card.ability.spades.x_mult, card.ability.spades.extra_cards, card.ability.spades.hands, card.ability.spades.discards } }
-end
-
-function jokerInfo.generate_ui(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
-    if card.area and card.area == G.jokers or card.config.center.discovered then
-        -- If statement makes it so that this function doesnt activate in the "Joker Unlocked" UI and cause 'Not Discovered' to be stuck in the corner
-        full_UI_table.name = localize{type = 'name', key = "j_csau_sts_"..card.ability.form, set = self.set, name_nodes = {}, vars = specific_vars or {}}
-    end
-    localize{type = 'descriptions', key = "j_csau_sts_"..card.ability.form, set = self.set, nodes = desc_nodes, vars = self.loc_vars(self, info_queue, card).vars}
+    return { 
+        vars = {
+            card.ability.diamonds.mult_mod,
+            card.ability.diamonds.mult,
+            card.ability.spades.x_mult,
+            card.ability.spades.extra_cards,
+            card.ability.spades.hands,
+            card.ability.spades.discards
+        },
+        key = "j_csau_sts_"..card.ability.form
+    }
 end
 
 function jokerInfo.set_sprites(self, card, _front)

--- a/items/jokers/ufo.lua
+++ b/items/jokers/ufo.lua
@@ -2,9 +2,7 @@
 local jokerInfo = {
     name = "UFO COMODIN",
     config = {
-        wasShop = false,
         extra = 3,
-        abducted = false,
         ufo_rounds = 0,
         card_key = nil,
         card_ability = nil,
@@ -57,8 +55,8 @@ function jokerInfo.add_to_deck(self, card)
     for k, v in pairs(G.jokers.cards) do
         if not v.ability.eternal then deletable_jokers[#deletable_jokers + 1] = v end
     end
+
     if #deletable_jokers > 0 then
-        card.ability.abducted = true
         local _card =  pseudorandom_element(deletable_jokers, pseudoseed('ufo_choice'))
         card.ability.card_key = _card.config.center.key
         card.ability.card_ability = _card.ability
@@ -69,32 +67,52 @@ function jokerInfo.add_to_deck(self, card)
                 _card:start_dissolve()
                 return true end
         }))
+        card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_abducted')})
     end
-
 end
 
 function jokerInfo.calculate(self, card, context)
-    local bad_context = context.repetition or context.individual or context.blueprint
-    if card.ability.abducted then
-        if context.end_of_round and not bad_context then
-            card.ability.ufo_rounds = card.ability.ufo_rounds + 1
-            if card.ability.ufo_rounds == card.ability.extra then
-                local eval = function(card) return not card.REMOVED end
-                juice_card_until(card, eval, true)
-            end
-            return {
-                message = (card.ability.ufo_rounds < card.ability.extra) and (card.ability.ufo_rounds..'/'..card.ability.extra) or localize('k_active_ex'),
-                colour = G.C.FILTER
-            }
+    if context.blueprint or card.debuff then
+        return
+    end
+    
+    if not card.ability.card_key then
+        if context.card_added and not context.card.ability.eternal then
+            card.ability.card_key = context.card.config.center.key
+            card.ability.card_ability = context.card.ability
+            G.E_MANAGER:add_event(Event({
+                trigger = 'before',
+                delay = 0.75,
+                func = function()
+                    context.card:start_dissolve()
+                    return true end
+            }))
+            card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_abducted')})
         end
-        if context.selling_self and (card.ability.ufo_rounds >= card.ability.extra) and not context.blueprint then
-            card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = localize('k_duplicated_ex')})
-            local _card = SMODS.create_card({ set = 'Joker', area = G.jokers, key = card.ability.card_key, edition = 'e_negative' } )
-            _card.ability = card.ability.card_ability
-            _card:start_materialize()
-            _card:add_to_deck()
-            G.jokers:emplace(_card)
+
+        return
+    end
+
+    if context.end_of_round and context.main_eval then
+        card.ability.ufo_rounds = card.ability.ufo_rounds + 1
+        if card.ability.ufo_rounds == card.ability.extra then
+            local eval = function(condition_card) return not condition_card.REMOVED end
+            juice_card_until(card, eval, true)
         end
+
+        return {
+            message = (card.ability.ufo_rounds < card.ability.extra) and (card.ability.ufo_rounds..'/'..card.ability.extra) or localize('k_active_ex'),
+            colour = G.C.FILTER
+        }
+    end
+
+    if context.selling_self and (card.ability.ufo_rounds >= card.ability.extra) then
+        card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_duplicated_ex')})
+        local dropped_card = SMODS.create_card({ set = 'Joker', area = G.jokers, key = card.ability.card_key, edition = 'e_negative' } )
+        dropped_card.ability = card.ability.card_ability
+        dropped_card:start_materialize()
+        dropped_card:add_to_deck()
+        G.jokers:emplace(dropped_card)
     end
 end
 

--- a/items/jokers/villains.lua
+++ b/items/jokers/villains.lua
@@ -29,14 +29,19 @@ end
 function jokerInfo.calculate(self, card, context)
     if context.joker_main then
         local play_more_than = 0
-        local most_played = context.scoring_name
+        local most_played = {}
         for k, v in pairs(G.GAME.hands) do
-            if v.played >= play_more_than and v.visible then
-                play_more_than = v.played
-                most_played = k
+            if v.visible and v.played > 0 then
+                if v.played > play_more_than then
+                    most_played = {[k] = true}
+                    play_more_than = v.played
+                elseif v.played == play_more_than then
+                    most_played[k] = true
+                end
             end
         end
-        if most_played == context.scoring_name then
+        
+        if most_played[context.scoring_name] then
             return {
                 chips = card.ability.extra.chips,
                 mult = card.ability.extra.mult

--- a/items/vouchers/lampoil.lua
+++ b/items/vouchers/lampoil.lua
@@ -31,15 +31,12 @@ function voucherInfo.redeem(self, card, area, copier)
         -- recreate shop card UIs for existing cards
         for k, v in pairs(G.I.CARD) do
             if v.area and v.area.config.type == 'shop' then
-                if v.children.price then v.children.price:remove() end
-                v.children.price = nil
-                if v.children.buy_button then v.children.buy_button:remove() end
-                v.children.buy_button = nil
-                if v.children.buy_and_use_button then v.children.buy_and_use_button:remove() end
-                v.children.buy_and_use_button = nil
+                if v.children.price then v.children.price:remove(); v.children.price = nil end
+                if v.children.buy_button then v.children.buy_button:remove(); v.children.buy_button = nil end
+                if v.children.buy_and_use_button then v.children.buy_and_use_button:remove(); v.children.buy_and_use_button = nil end
                 remove_nils(v.children)
 
-                create_shop_card_ui(v)
+                create_shop_card_ui(v, nil, v.area)
             end
         end
     end

--- a/items/vouchers/ropebombs.lua
+++ b/items/vouchers/ropebombs.lua
@@ -42,15 +42,12 @@ function voucherInfo.redeem(self, card, area, copier)
         -- recreate shop card UIs for existing cards
         for k, v in pairs(G.I.CARD) do
             if v.area and v.area.config.type == 'shop' then
-                if v.children.price then v.children.price:remove() end
-                v.children.price = nil
-                if v.children.buy_button then v.children.buy_button:remove() end
-                v.children.buy_button = nil
-                if v.children.buy_and_use_button then v.children.buy_and_use_button:remove() end
-                v.children.buy_and_use_button = nil
+                if v.children.price then v.children.price:remove(); v.children.price = nil end
+                if v.children.buy_button then v.children.buy_button:remove(); v.children.buy_button = nil end
+                if v.children.buy_and_use_button then v.children.buy_and_use_button:remove(); v.children.buy_and_use_button = nil end
                 remove_nils(v.children)
 
-                create_shop_card_ui(v)
+                create_shop_card_ui(v, nil, v.area)
             end
         end
     end

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -491,6 +491,7 @@ return {
 			k_bighunks = "Mult!",
 			k_vhs_fin = "Fin!",
 			k_outlaw_default = "Debuffs all ranks scored last hand",
+			k_abducted = "Abducted!",
 			k_ufo_alert = "Nothing to abduct!",
 			b_planet_card = "Planet Card",
 			k_survived = 'Survived!',
@@ -1308,7 +1309,10 @@ return {
 				},
 			},
 			j_csau_chad = {
-				name = "No No No No No No No No No No No",
+				name = {
+					"No No No No No No",
+					"No No No No No",
+				},
 				text = {
 					"Greetings, Cloud, it is me, Chudlot. As you can plainly see,",
 					"my lifelong dream of transmogrifying myself into a Joker",
@@ -1322,10 +1326,14 @@ return {
 				},
 			},
 			j_csau_chad_detailed = {
-				name = "No No No No No No No No No No No",
+				name = {
+					"No No No No No No",
+					"No No No No No",
+				},
 				text = {
-					"{X:mult,C:white}X2{} Mult for every other {C:attention}copy{} of",
-					"this Joker, {C:attention}Showman{}, or {C:attention}Hanging Chad{}"
+					"{X:mult,C:white}X2{} Mult for every other",
+					"{C:attention}copy{} of this Joker, {C:attention}Showman{},",
+					"or {C:attention}Hanging Chad{}"
 				},
 			},
 			j_csau_disguy = {
@@ -1359,9 +1367,9 @@ return {
 			j_csau_odio_detailed = {
 				name = "Odious Joker",
 				text = {
-					"{C:attention}Transforms{} into a new form during each {C:attention}Boss Blind{}",
-					"Form determined by the current {C:attention}Ante{} level",
-					"{C:inactive}(Final transformation in {C:attention}Endless Mode{C:inactive})"
+					"{C:attention}Transforms{} into a new form",
+					"during each {C:attention}Boss Blind{}",
+					"Form determined by current {C:attention}Ante{}",
 				},
 			},
 			j_csau_odio1 = {
@@ -1445,7 +1453,10 @@ return {
 				}
 			},
 			j_csau_besomeone = {
-				name = "Be Someone Forever",
+				name = {
+					"{s:0.9}Be Someone{}",
+					"{s:0.9}Forever{}",
+				},
 				text = {
 					"Played {C:attention}High Cards{}",
 					"are redrawn",
@@ -1489,16 +1500,17 @@ return {
 			j_csau_maskedjoker = {
 				name = "Masked Joker",
 				text = {
-					"If played hand is all {C:attention}Steel Cards{},",
-					"each {C:attention}scoring{} card gives",
-					"{C:chips}+#1#{} Chips and {C:mult}+#2#{} Mult",
+					"If played hand contains only",
+					"{C:attention}Steel Cards{}, each {C:attention}scoring{} card",
+					"gives {C:chips}+#1#{} Chips and {C:mult}+#2#{} Mult",
 				},
 			},
 			j_csau_deathcard = {
 				name = "Deathcard",
 				text = {
-					"When {C:attention}sold{}, reappears in the next shop",
-					"with {C:mult}+#3#{} Mult and {C:money}+$#1#{} Cost",
+					"When {C:attention}sold{}, reappears in the",
+					"next shop with {C:mult}+#3#{} Mult",
+					"and {C:money}+$#1#{} Cost",
 					"{C:inactive}(Currently {}{C:mult}+#2#{}{C:inactive} Mult{}{C:inactive}){}",
 				},
 			},
@@ -1656,8 +1668,9 @@ return {
 			j_csau_depressedbrother = {
 				name = "Depressed Brother",
 				text = {
-					"All {C:attention}unscored{} cards have {C:green}#1# in #2#{} chance",
-					"to permanently gain {C:mult}+#3#{} Mult"
+					"All {C:attention}unscored{} cards have a",
+					"{C:green}#1# in #2#{} chance to permanently",
+					"gain {C:mult}+#3#{} Mult"
 				},
 			},
 			j_csau_code = {
@@ -1768,11 +1781,10 @@ return {
 			j_csau_kings = {
 				name = "2 Kings 2:23-24",
 				text = {
-					"Destroys {C:attention}42{} random cards",
-					"in your deck when acquired.",
-					"{C:inactive}(Cards destroyed this way are{}",
-					"{C:inactive}added back to your deck when{}",
-					"{C:inactive}this Joker is sold/destroyed){}",
+					"Removes {C:attention}42{} random cards",
+					"in your deck when acquired",
+					"and returns them when this",
+					"Joker is {C:attention}sold{} or {C:attention}destroyed{}"
 				},
 				unlock = {
 					"Use an {E:1,C:spectral}Immolate{} card"
@@ -1821,13 +1833,11 @@ return {
 				name = "Let Fate Decide",
 				text = {
 					"Rolls a chance cube at end of round",
-					"{C:green}1 in 6{} chance to create a",
-					"random {C:attention}Free Joker Tag{},",
-					"{C:green}1 in 6{} chance to create a",
-					"random {C:attention}Booster Pack Tag{},",
-					"{C:green}1 in 6{} chance to create",
-					"{C:attention}2{} completely random {C:attention}Tags{},",
-					"or {C:green}3 in 6{} chance to get nothing",
+					"{C:green}1 in 2{} chance of no effect",
+					"{C:green}1 in 2{} chance to create {C:attention}1{} random",
+					"{C:attention}Joker Tag{}, {C:attention}1{} random {C:attention}Booster Pack Tag{},",
+					"or {C:attention}2{} completely random {C:attention}Tags{}",
+					
 					"{s:0.8,C:inactive}(Odds not affected by probability manipulation){}"
 				},
 			},
@@ -1843,10 +1853,10 @@ return {
 			j_csau_muppet = {
 				name = "Movin' Right Along",
 				text = {
-					"This Joker gains {X:mult,C:white}X#2#{} Mult for each",
-					"time you leave the shop with the",
-					"same amount of {C:money}money{} you had",
-					"when you entered",
+					"This Joker gains {X:mult,C:white}X#2#{} Mult",
+					"each time you leave the {C:attention}shop{}",
+					"with the same amount of {C:money}money{}",
+					"you had when you entered",
 					"{C:inactive}(Currently {}{X:mult,C:white}X#1#{} {C:inactive}Mult){}",
 				},
 				unlock = {
@@ -1865,8 +1875,9 @@ return {
 			j_csau_joeycastle = {
 				name = "Joey's Castle",
 				text = {
-					"Earn {C:money}$#1#{} per discarded {V:1}#2#{} card,",
-					"{C:inactive}suit changes every round"
+					"Earn {C:money}$#1#{} per discarded",
+					"{V:1}#2#{} card,",
+					"{C:inactive,s:0.8}suit changes every round"
 				},
 			},
 			j_csau_grand = {
@@ -1949,9 +1960,8 @@ return {
 			j_csau_meteor = {
 				name = "Meteor",
 				text = {
-					"Played {C:attention}7s{} that aren't {C:attention}Glass Cards",
-					"act as them as well as their",
-					"current {C:attention}Enhancement"
+					"Played {C:attention}7s{} act",
+					"as {C:attention}Glass Cards{}"
 				},
 				unlock={
 					"Sell or destroy",
@@ -1959,9 +1969,13 @@ return {
 				},
 			},
 			j_csau_frich = {
-				name = "Gourmand of Faramore",
+				name = {
+					"Gourmand of",
+					"Faramore",
+				},
 				text = {
-					"{C:attention}Food Jokers{} appear twice as often"
+					"{C:attention}Food Jokers{} appear",
+					"{C:attention}twice{} as often"
 				},
 				unlock={
 					"Discover",
@@ -1969,7 +1983,10 @@ return {
 				},
 			},
 			j_csau_bunji = {
-				name = "Scourge Of Pantsylvania",
+				name = {
+					"Scourge Of",
+					"Pantsylvania",
+				},
 				text = {
 					"{C:attention}Food Jokers{} never expire"
 				},
@@ -1979,7 +1996,10 @@ return {
 				},
 			},
 			j_csau_koffing = {
-				name = "That Fucking Koffing Again",
+				name = {
+					"{s:0.9}That Fucking{}",
+					"{s:0.9}Koffing Again{}",
+				},
 				text = {
 					"Your first {C:attention}Shop Reroll{} each",
 					"shop rerolls {C:attention}Booster Packs"
@@ -1988,8 +2008,9 @@ return {
 			j_csau_dud = {
 				name = "The Dud",
 				text = {
-					"When sold, removes all {C:attention}stickers",
-					"from a random {C:attention}Joker{} with stickers"
+					"When sold, removes all",
+					"{C:attention}stickers from a random",
+					"{C:attention}Joker{} with stickers"
 				},
 				unlock = {
 					"Win a run with any",
@@ -2017,17 +2038,19 @@ return {
 			j_csau_grannycream = {
 				name = "Granny Cream",
 				text = {
-					"If scored hand has under {C:chips}#1#{} Chips,",
-					"spend Chips from this Joker to make it {C:chips}#1#{}",
+					"If scored hand has under",
+					"{C:chips}#1#{} Chips, spend Chips from",
+					"this Joker to make it {C:chips}#1#{}",
 					"{C:inactive}({}{C:chips}#2#{}{C:inactive} Chips remaining){}",
 				},
 			},
 			j_csau_drippy = {
 				name = "Dripping Joker",
 				text = {
-					"When {C:attention}first hand{} of round is played,",
-					"add a random {C:attention}Enhancement{}",
-					"to a card held in hand",
+					"When {C:attention}first hand{} of round",
+					"is played, add a random",
+					"{C:attention}Enhancement{} to a card",
+					"held in hand",
 				},
 			},
 			j_csau_sts = {
@@ -2146,7 +2169,8 @@ return {
 				text = {
 					"{C:tarot}Wheel of Fortune{} cards have",
 					"{C:green}3 in 4{} chance to succeed",
-					"{s:0.8,C:inactive}(Odds not affected by probability manipulation){}",
+					"{s:0.8,C:inactive}(Odds not affected by",
+					"{s:0.8,C:inactive}probability manipulation){}",
 				},
 				unlock={
 					"Have a {E:1,C:tarot}Wheel of Fortune{} trigger",
@@ -2202,7 +2226,8 @@ return {
 			j_csau_facade = {
 				name = "Couple's Joker",
 				text = {
-					"{C:mult}+#1#{} Mult for every {C:attention}Pair{} played this run",
+					"{C:mult}+#1#{} Mult for every {C:attention}Pair{}",
+					"played this run",
 					"{C:inactive}(Currently {}{C:mult}+#2#{}{C:inactive} Mult{}{C:inactive}){}",
 				},
 			},
@@ -2270,8 +2295,9 @@ return {
 			j_csau_passport = {
 				name = "Passport",
 				text = {
-					"This Joker gains {X:mult,C:white} X#1# {} Mult for",
-					"each {C:attention}Voucher{} redeemed this run",
+					"This Joker gains {X:mult,C:white} X#1# {} Mult",
+					"for each {C:attention}Voucher{} redeemed",
+					"this run",
 					"{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
 				},
 			},
@@ -2336,10 +2362,15 @@ return {
 				},
 			},
 			j_csau_protogent = {
-				name = "Protegent Antivirus",
+				name = {
+					"Protegent",
+					"Antivirus",
+				},
 				text = {
-					"{C:green}#1# in #2#{} chance to disable {C:attention}Boss Blinds{}",
-					"{C:green}#1# in #3#{} chance to prevent death",
+					"{C:green}#1# in #2#{} chance to",
+					"disable {C:attention}Boss Blinds{}",
+					"{C:green}#1# in #3#{} chance",
+					"to prevent {C:red,E:1}death{}",
 					"{S:1.1,C:red,E:2}self destructs{}",
 				},
 			},
@@ -2391,8 +2422,9 @@ return {
 			j_csau_mrkill = {
 				name = "Mr. Kill",
 				text = {
-					"If {C:attention}first discard{} of round has only",
-					"{C:attention}1{} card, {C:attention}destroy{} it and gain its Chips",
+					"If {C:attention}first discard{} of round",
+					"has only {C:attention}1{} card, {C:attention}destroy{} it",
+					"and gain its Chips",
 					"{C:inactive}(Currently {C:chips}+#1#{}{C:inactive} Chips)",
 				},
 			},
@@ -2412,9 +2444,10 @@ return {
 			j_csau_memehouse = {
 				name = "Meme House",
 				text = {
-					"Create a {C:tarot}Tarot{} card if played hand",
-                    "contains a {C:attention}Full House{} and",
-					"{C:attention}3{} or more {C:attention}face{} cards",
+					"Create a {C:tarot}Tarot{} card if",
+					"played hand contains a",
+					"{C:attention}Full House{} and {C:attention}3{} or more",
+					"{C:attention}face{} cards",
 					"{C:inactive}(Must have room)",
 				},
 			},
@@ -2444,7 +2477,7 @@ return {
 			j_csau_vinewrestle = {
 				name = "Vinewrestle",
 				text = {
-					"Create a {C:attention}random free Joker Tag",
+					"Create a random {C:attention}Joker Tag{}",
 					"when {C:attention}Boss Blind{} is defeated",
 				},
 			},
@@ -2465,8 +2498,9 @@ return {
 			j_csau_skeletonmetal = {
 				name = "Skeleton Metal",
 				text = {
-					"When {C:attention}final hand{} of round is played,",
-					"add {C:attention}#1#{} random {C:attention}Steel Cards{} to your hand",
+					"When {C:attention}final hand{} of round",
+					"is played, add {C:attention}#1#{} random",
+					"{C:attention}Steel Cards{} to your hand",
 				},
 			},
 			j_csau_byebye = {
@@ -2483,10 +2517,12 @@ return {
 					"on any difficulty",
 				},
 			},
-			j_csau_ufo={
-				name="UFO COMODIN",
-				text={
-					"Upon purchase, {C:attention}removes{} a random Joker",
+			j_csau_ufo = {
+				name = "UFO COMODIN",
+				text = {
+					"Upon purchase, {C:attention}removes{}",
+					"a random Joker",
+					"{s:0.1} {}",
 					"After {C:attention}#1#{} rounds, sell this card",
 					"to return it {C:dark_edition}Negative{}",
 				},
@@ -2494,9 +2530,11 @@ return {
 			j_csau_wigsaw = {
 				name = "Wigsaw",
 				text = {
-					"All {C:attention}suit{} effects target the suit with",
-					"the {C:attention}most cards{} in your full deck instead",
-					"{C:inactive}(Not active if {C:attention}2 or more suits{C:inactive} are tied)"
+					"All {C:attention}suit{} effects target the",
+					"suit with the {C:attention}most cards{}",
+					"in your full deck",
+					"{C:inactive,s:0.8}(Not applicable if{}",
+					"{C:attention,s:0.8}multiple suits{} {C:inactive,s:0.8}are tied){}"
 				},
 				unlock = {
 					"{E:1,s:1.3}?????"
@@ -2527,8 +2565,8 @@ return {
 			j_csau_photodad = {
 				name = "Photodad",
 				text = {
-					"When {C:attention}final hand{} of round is played,",
-					"create a {C:tarot}The Arrow{} card",
+					"When {C:attention}final hand{} of round",
+					"is played, create {C:tarot}The Arrow{}",
 					"{C:inactive}(Must have room)",
 				},
 			},
@@ -2540,16 +2578,21 @@ return {
 				},
 			},
 			j_csau_genres = {
-				name = "Battle of the Genres",
+				name = {
+					"{s:0.8}Battle of{}",
+					"{s:0.8}the Genres{}"
+				},
 				text = {
-					"{C:attention}+#1#{} Hand Size for each {C:vhs}VHS Tape{} held",
+					"{C:attention}+#1#{} Hand Size for",
+					"each {C:vhs}VHS Tape{} held",
 					"{C:inactive}(Currently {}{C:attention}+#2#{}{C:inactive} Hand Size{}{C:inactive}){}",
 				},
 			},
 			j_csau_endlesstrash = {
 				name = "ENDLESS TRASH",
 				text = {
-					"{C:mult}+#1#{} Discard for each {C:vhs}VHS Tape{} held",
+					"{C:mult}+#1#{} Discard for",
+					"each {C:vhs}VHS Tape{} held",
 				},
 			},
 			j_csau_hack = {
@@ -2557,7 +2600,8 @@ return {
 				text = {
 					"{C:chips}+#1#{} Chips per unique",
 					"{C:vhs}VHS Tape{} obtained this run",
-					"Double if {C:attention}Director's Cut{} is redeemed",
+					"{C:attention}Double{} Chips if you",
+					"have {C:attention}Director's Cut{}",
 					"{C:inactive}(Currently {C:chips}+#2#{}{C:inactive} Chips)",
 				},
 			},
@@ -2660,7 +2704,10 @@ return {
 				},
 			},
 			c_csau_swhs = {
-				name = "Star Wars Holiday Special",
+				name = {
+					"{s:0.9}Star Wars{}",
+					"{s:0.9}Holiday Special{}",
+				},
 				text = {
 					"While {C:attention}playing{}, each played card",
 					"gives {C:money}$#1#{} when scored",
@@ -2710,13 +2757,16 @@ return {
 			c_csau_nukie = {
 				name = "Nukie",
 				text = {
-					"While {C:attention}playing{}, each {C:attention}Wheel of Fortune{}",
-					"used has a chance to give {C:dark_edition}Negative",
-					"{C:vhs}Running Time{}: {C:attention}#1#{} Wheel of Fortunes"
+					"While {C:attention}playing{}, {C:attention}Wheel of Fortune{}",
+					"has a chance to give{C:dark_edition}Negative",
+					"{C:vhs}Running Time{}: {C:attention}#1#{} Wheels"
 				},
 			},
 			c_csau_sataniccults = {
-				name = "Law Enforcement Guide to Satanic Cults",
+				name = {
+					"{s:0.8}Law Enforcement Guide to{}",
+					"Satanic Cults"
+				},
 				text = {
 					"While {C:attention}playing{}, {C:attention}Gold Cards{} give",
 					"{X:mult,C:white}X#1#{} Mult when held in hand",
@@ -2734,23 +2784,25 @@ return {
 			c_csau_topslots = {
 				name = "Top Slots",
 				text = {
-					"While {C:attention}playing{}, at end of round",
-					"gain {C:money}$#1#{} per {C:attention}#2#%{} over required chips",
-					"{C:inactive}(Max of {}{C:money}$#3#{}{C:inactive}){}",
-					"{C:green}#4# in #5#{} chance to {C:attention}double{} winnings",
-					"{C:green}#4# in #6#{} chance to {C:attention}triple{} winnings",
+					"While {C:attention}playing{}, gain {C:money}$#1#{} {C:inactive}[Max:{} {C:money}$#3#{}{C:inactive}]{}",
+					"per {C:attention}#2#%{} over required chips at",
+					"end of round",
+					"{C:green}#4# in #5#{} chance to {C:attention}double{}",
+					"{C:green}#4# in #6#{} chance to {C:attention}triple{}",
 					"{C:vhs}Running Time{}: {C:attention}#7#{} Rounds"
 				},
 			},
 			c_csau_topslots_alt_title = {
-				name = "Top Slots - Spotting The Best",
+				name = {
+					"Top Slots -",
+					"{S:0.9}Spotting The Best{}",
+				},
 				text = {
-					"While {C:attention}playing{}, at end of round",
-					"gain {C:money}$#1#{} per {C:attention}#2#%{} over the required",
-					"chips to beat the blind",
-					"{C:inactive}(Max initial winnings: {C:money}$#3#{C:inactive})",
-					"{C:green}#4# in #5#{} chance to {C:attention}double{} winnings",
-					"{C:green}#4# in #6#{} chance to {C:attention}triple{} winnings",
+					"While {C:attention}playing{}, gain {C:money}$#1#{} {C:inactive}[Max:{} {C:money}$#3#{}{C:inactive}]{}",
+					"per {C:attention}#2#%{} over required chips at",
+					"end of round",
+					"{C:green}#4# in #5#{} chance to {C:attention}double{}",
+					"{C:green}#4# in #6#{} chance to {C:attention}triple{}",
 					"{C:vhs}Running Time{}: {C:attention}#7#{} Rounds"
 				},
 			},
@@ -2772,9 +2824,9 @@ return {
 			c_csau_fatefulfindings = {
 				name = "Fateful Findings",
 				text = {
-					"While {C:attention}playing{}, steal the next {C:tarot}Tarot{}, {C:planet}Planet{}",
-					"or {C:spectral}Spectral{} card found in a {C:attention}Booster Pack{}",
-					"and put it in your consumables",
+					"While {C:attention}playing{}, {C:attention}steal{} the first",
+					"{C:tarot}Tarot{}, {C:planet}Planet{} or {C:spectral}Spectral{} card",
+					"from a {C:attention}Booster Pack{}",
 					"{C:vhs}Running Time{}: {C:attention}#1#{} Cards"
 				},
 			},
@@ -2789,8 +2841,9 @@ return {
 			c_csau_devilstory = {
 				name = "Devil Story",
 				text = {
-					"While {C:attention}playing{}, each played {C:attention}Enhanced{} card",
-					"gives {C:money}$#1#{} when scored",
+					"While {C:attention}playing{}, each played",
+					"{C:attention}Enhanced{} card gives {C:money}$#1#{}",
+					"when scored",
 					"{C:vhs}Running Time{}: {C:attention}#2#{} Cards"
 				},
 			},
@@ -2803,7 +2856,10 @@ return {
 				},
 			},
 			c_csau_tbone = {
-				name = "T-Bone's World of Clowning",
+				name = {
+					"{s:0.9}T-Bone's World{}",
+					"{s:0.9}of Clowning{}",
+				},
 				text = {
 					"Each Joker gives {C:mult}+#1#{} Mult",
 					"while this tape is {C:attention}playing{}",
@@ -2811,7 +2867,10 @@ return {
 				},
 			},
 			c_csau_wwvcr = {
-				name = "Wayne's World VCR Board Game",
+				name = {
+					"{s:0.9}Wayne's World{}",
+					"{s:0.9}VCR Board Game{}",
+				},
 				text = {
 					"While {C:attention}playing{}, {C:chips}+#1#{} Chips if you",
 					"do not have the {C:inactive}Grey Poupon{s:0.55}TM{}",
@@ -2842,7 +2901,11 @@ return {
 				},
 			},
 			c_csau_osteo = {
-				name = "The Osteoporosis Dance",
+				name = {
+					"{s:0.9}The{}",
+					"{s:0.8}Osteoporosis{}",
+					"{s:0.9}Dance{}",
+				},
 				text = {
 					"While {C:attention}playing{}, gain {C:blue}+1{} Hand",
 					"when {C:attention}Blind{} is selected",
@@ -2860,9 +2923,8 @@ return {
 			c_csau_lowblow = {
 				name = "Low Blow",
 				text = {
-					"{C:attention}Retrigger{} lowest ranked card used",
-					"in scoring {C:attention}#1#{} additional times",
-					"while this tape is {C:attention}playing{}",
+					"While {C:attention}playing{}, retrigger the ",
+					"{C:attentionlowest ranked{} scoring card {C:attention}#1#{} times",
 					"{C:vhs}Running Time{}: {C:attention}#2#{} Hands"
 				},
 			},
@@ -2878,8 +2940,9 @@ return {
 				name = "Space Cop",
 				text = {
 					"While {C:attention}playing{}, {C:planet}Planet Cards{}",
-					"level up by {C:attention}double{} the standard increment",
-					"{C:vhs}Running Time{}: {C:attention}#1# {C:planet}Planet Cards"
+					"level up by {C:attention}double{}",
+					"the standard increment",
+					"{C:vhs}Running Time{}: {C:attention}#1# {C:planet}Planets"
 				},
 			},
 			c_csau_theroom = {
@@ -2917,10 +2980,12 @@ return {
 			c_csau_ritf_detailed = {
 				name = "Robot in the Family",
 				text = {
-					"While {C:attention}playing{}, all scored cards give Mult",
-					"and all cards held in hand give Chips",
+					"While playing{}, all scored cards",
+					"give Mult and all cards held in hand",
+					"give Chips",
 					"{s:0.1} {}",
-					"Mult and Chips given are digits of pi in order",
+					"Mult and Chips given are the",
+					"digits of pi in order",
 					"{C:vhs}Running Time{}: {C:attention}#1#{} Hands"
 				},
 			},
@@ -2941,7 +3006,10 @@ return {
 				},
 			},
 			c_csau_donbeveridge = {
-				name = "Don Beveridge Customerization Seminar",
+				name = {
+					"Don Beveridge",
+					"{s:0.9}Customerization Seminar{}",
+				},
 				text = {
 					"While {C:attention}playing{}, {C:attention}Food Jokers{}",
 					"do not expire",
@@ -2952,14 +3020,17 @@ return {
 				name = "Alien Private Eye",
 				text = {
 					"While {C:attention}playing{}, scoring cards give",
-					"{X:mult,C:white}X#1#{} and add {C:green}+#2#{} chance to this Tape",
-					"When completely used, you {C:red,E:1}die{}",
+					"{X:mult,C:white}X#1#{} and add {C:green}+#2#{} chance",
 					"When sold, {C:green}#3# in #4#{} chance to {C:red,E:1}die{}",
+					"When completely used, you {C:red,E:1}die{}",
 					"{C:vhs}Running Time{}: {C:attention}#5#{} cards"
 				},
 			},
 			c_csau_supershow = {
-				name = "The Super Mario Bros. Super Show",
+				name = {
+					"{s:0.8}The Super Mario Bros.{}",
+					"Super Show",
+				},
 				text = {
 					"While {C:attention}playing{}, creates {C:attention}copies",
 					"of destroyed cards and gives",
@@ -3428,8 +3499,8 @@ return {
 			v_csau_plant = {
 				name = 'Plant Appraiser',
 				text = {
-					"{C:stand}Evolved Stands{} can be purchased",
-					"from the {C:attention}shop{}"
+					"{C:stand}Evolved Stands{} can be",
+					"purchased from the {C:attention}shop{}"
 				},
 				unlock = {
 					"Buy a total of",

--- a/lovely/wigsaw.toml
+++ b/lovely/wigsaw.toml
@@ -222,14 +222,3 @@ match_indent = true
 times = 1
 
 
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''local faces = false'''
-position = "after"
-payload = '''sendDebugMessage('rtb code')'''
-match_indent = true
-times = 1
-
-
-


### PR DESCRIPTION
- Fixed Morshu Vouchers to make "Save" buttons appear in the shop they are purchased
- Reworked a number of cards to condense or format descriptions, primarily to avoid overly-long single lines or titles
  - Reduced the minimal scale factor for badges to prevent "JoJo's Bizarre Adventure" badges filling up the card width
- Banned Mocha Mike from Not My Bag, Baby challenge
- Battle of the Genres now checks current hand mod to correctly reset it when needed
- Skeleton Metal's blueprint compatibility fixed
- Jokers of Circumstance now recognizes multiple tied most played hands
- UFO COMODIN will now abduct cards added if it exists in your Joker slots without an abducted card
- 2 Kings visually reworked to hold cards in a cardarea beneath the Joker rather than destroying them