### PR TITLE
Vg/bugfix bonanza

### DIFF
--- a/includes/hooks/UI_definitions.lua
+++ b/includes/hooks/UI_definitions.lua
@@ -449,3 +449,33 @@ function G.UIDEF.challenge_description_tab(args)
 	end
 	return ref_cdt(args)
 end
+
+
+local ref_create_shop = create_card_for_shop
+function create_card_for_shop(area)
+	if area == G.shop_jokers and next(G.GAME.csau_saved_deathcards) and G.GAME.csau_rerolls_this_round == 0
+	and not (G.SETTINGS.tutorial_progress and G.SETTINGS.tutorial_progress.forced_shop
+	and G.SETTINGS.tutorial_progress.forced_shop[#G.SETTINGS.tutorial_progress.forced_shop]) then
+		-- hate doing this
+		local pop_deathcard = table.remove(G.GAME.csau_saved_deathcards, 1)
+		local card = Card(
+			area.T.x + area.T.w/2,
+			area.T.y,
+			G.CARD_W,
+			G.CARD_H,
+			nil,
+			G.P_CENTERS[pop_deathcard.key]
+		)
+
+		card.ability.id = pop_deathcard.id
+		card.ability.times_sold = pop_deathcard.times_sold
+		card.cost = card.cost + (card.ability.extra.money_mod * card.ability.times_sold)
+		card.ability.extra.mult = card.ability.extra.mult + (card.ability.extra.mult_mod * card.ability.times_sold)
+		card:set_edition(pop_deathcard.edition)
+		create_shop_card_ui(card)
+
+		return card
+	end
+
+	return ref_create_shop(area)
+end

--- a/includes/hooks/button_callbacks.lua
+++ b/includes/hooks/button_callbacks.lua
@@ -159,6 +159,7 @@ end
 -- this also incorporates koffing's ref to reroll so I don't have them in two places
 local reroll_shopref = G.FUNCS.reroll_shop
 function G.FUNCS.reroll_shop(e)
+    G.GAME.csau_rerolls_this_round = G.GAME.csau_rerolls_this_round + 1
     local ret = reroll_shopref(e)
     G.GAME.csau_shop_dollars_spent = G.GAME.csau_shop_dollars_spent + G.GAME.current_round.reroll_cost
     check_for_unlock({type = 'csau_spent_in_shop', dollars = G.GAME.csau_shop_dollars_spent})
@@ -208,6 +209,7 @@ local ref_uc = G.FUNCS.use_card
 G.FUNCS.use_card = function(e, mute, nosave)
     local card = e.config.ref_table
     if card.area == G.consumeables and (card.ability.activation or (card.config.center.activate and type(card.config.center.activate) == 'function')) then
+        sendDebugMessage('vhs code')
         if card.config.center.activate and type(card.config.center.activate) == 'function' then
             card.config.center.activate(card.config.center, card, not card.ability.activated)
         end

--- a/includes/hooks/smods.lua
+++ b/includes/hooks/smods.lua
@@ -2,6 +2,7 @@ function SMODS.current_mod.reset_game_globals(run_start)
     if run_start then
         G.GAME.modifiers.max_stands = G.GAME.modifiers.max_stands or 1
 		G.GAME.morshu_cards = 0
+		G.GAME.csau_saved_deathcards = {}
 
 		if G.GAME.modifiers.csau_marathon then
 			-- set all consumable types besides VHS to 0 shop rate
@@ -14,6 +15,7 @@ function SMODS.current_mod.reset_game_globals(run_start)
 		end
     end
 
+	G.GAME.csau_rerolls_this_round = 0
 	G.GAME.csau_shop_dollars_spent = 0
     csau_reset_paper_rank()
 

--- a/includes/utility.lua
+++ b/includes/utility.lua
@@ -1009,7 +1009,7 @@ function SMODS.food_expires()
 	local expires = true
 	for _, v in ipairs(bunjis) do
 		if not v.debuff then
-			expires = true
+			expires = false
 			break
 		end
 	end

--- a/items/jokers/bootleg.lua
+++ b/items/jokers/bootleg.lua
@@ -137,7 +137,7 @@ end
 
 function jokerInfo.calculate(self, card, context)
     if context.setting_blind and not card.getting_sliced and not card.debuff and not context.blueprint and not context.retrigger_joker then
-        local center = G.P_CENTERS['j_csau_kings']--pseudorandom_element(G.P_CENTER_POOLS.Joker, pseudoseed('csau_bootleg_center'))
+        local center = pseudorandom_element(G.P_CENTER_POOLS.Joker, pseudoseed('csau_bootleg_center'))
         reduced_set_ability(card, center)
         card.ability.bootlegged_key = center.key
         card.config.center.atlas = 'csau_bootleg'

--- a/items/jokers/bootleg.lua
+++ b/items/jokers/bootleg.lua
@@ -137,7 +137,7 @@ end
 
 function jokerInfo.calculate(self, card, context)
     if context.setting_blind and not card.getting_sliced and not card.debuff and not context.blueprint and not context.retrigger_joker then
-        local center = pseudorandom_element(G.P_CENTER_POOLS.Joker, pseudoseed('csau_bootleg_center'))
+        local center = G.P_CENTERS['j_csau_kings']--pseudorandom_element(G.P_CENTER_POOLS.Joker, pseudoseed('csau_bootleg_center'))
         reduced_set_ability(card, center)
         card.ability.bootlegged_key = center.key
         card.config.center.atlas = 'csau_bootleg'

--- a/items/jokers/deathcard.lua
+++ b/items/jokers/deathcard.lua
@@ -2,7 +2,7 @@ local jokerInfo = {
 	name = 'Deathcard',
 	config = {
 		id = nil,
-		timesSold = nil,
+		times_sold = nil,
 		extra = {
 			money_mod = 5,
 			mult = 4,
@@ -23,30 +23,36 @@ function jokerInfo.loc_vars(self, info_queue, card)
 end
 
 function jokerInfo.add_to_deck(self, card)
-	card.sell_cost = math.max(1, math.floor(card.cost/2))
+	card:set_cost()
 	check_for_unlock({ type = "discover_deathcard" })
-	if card.ability.timesSold and to_big(card.ability.timesSold) >= to_big(5) then
+
+	if card.ability.num_sold and to_big(card.ability.num_sold) >= to_big(5) then
 		check_for_unlock({ type = "five_deathcard" })
 	end
+
 	if not card.ability.id then
-		if not G.GAME.uniqueDeathcardsAcquired then
-			G.GAME.uniqueDeathcardsAcquired = 1
-		else
-			G.GAME.uniqueDeathcardsAcquired = G.GAME.uniqueDeathcardsAcquired + 1
+		if not G.GAME.csau_unique_deathcards then
+			G.GAME.csau_unique_deathcards = (G.GAME.csau_unique_deathcards or 0) + 1
 		end
-		card.ability.id = G.GAME.uniqueDeathcardsAcquired
+		card.ability.id = G.GAME.csau_unique_deathcards
 	else
-		local other_dc = find_joker('Deathcard')
-		if other_dc[1] then
-			if other_dc[1].Mid.ability.id == card.ability.id then
-				G.GAME.uniqueDeathcardsAcquired = G.GAME.uniqueDeathcardsAcquired + 1
-				card.ability.id = G.GAME.uniqueDeathcardsAcquired
+		-- handles what occurs on copying
+		local other_dc = SMODS.find_card('j_csau_deathcard')
+		if next(other_dc) then
+			for _, v in ipairs(other_dc) do
+				if v ~= card and v.ability.id == card.ability.id then
+					G.GAME.csau_unique_deathcards = G.GAME.csau_unique_deathcards + 1
+					card.ability.id = G.GAME.csau_unique_deathcards
+					return
+				end
 			end
 		end
 	end
 end
 
 function jokerInfo.calculate(self, card, context)
+	if card.debuff then return end
+
 	if context.joker_main and context.cardarea == G.jokers then
 		return {
 			message = localize{type='variable',key='a_mult',vars={to_big(card.ability.extra.mult)}},
@@ -55,59 +61,15 @@ function jokerInfo.calculate(self, card, context)
 			card = card
 		}
 	end
-	if context.selling_self then
-		local stop = false
-		if G.GAME.sellShopJokersSold then
-			for i, v in ipairs(G.GAME.sellShopJokersSold) do
-				if v['key'] == card.config.center.key and v['id'] == card.ability.id then
-					stop = true
-				end
-			end
-		end
-		if not stop then
-			if card.ability.timesSold then
-				card.ability.timesSold = card.ability.timesSold + 1
-			else
-				card.ability.timesSold = 1
-			end
-			if not G.GAME.sellShopJokersSold then
-				G.GAME.sellShopJokersSold = {}
-			end
-			G.GAME.sellShopJokersSold[#G.GAME.sellShopJokersSold+1] = {key =card.config.center.key, id=card.ability.id, timesSold=card.ability.timesSold, edition=card.edition and card.edition.type or nil}
-			if G.GAME.spawnSellShopJokers then
-				G.GAME.spawnSellShopJokers = G.GAME.spawnSellShopJokers + 1
-			else
-				G.GAME.spawnSellShopJokers = 1
-			end
-		end
-	end
-end
 
-function jokerInfo.update(self, card)
-	if card.area and card.area.config.type == "shop" and G.GAME.sellShopJokersSold then
-		if #G.GAME.sellShopJokersSold > 0 and not card.ability.id and not card.ability.timesSold then
-			local death = G.GAME.sellShopJokersSold[1]
-			local id = death['id']
-			if death['edition'] then
-				if death['edition'] == "foil" then
-					card:set_edition({foil = true}, true, true)
-				elseif death['edition'] == "holo" then
-					card:set_edition({holo = true}, true, true)
-				elseif death['edition'] == "polychrome" then
-					card:set_edition({polychrome = true}, true, true)
-				elseif death['edition'] == "negative" then
-					card:set_edition({negative = true}, true, true)
-				end
-			end
-			card.ability.id = id
-			local timesSold = death['timesSold']
-			card.ability.timesSold = timesSold
-			local newcost = card.cost + (card.ability.extra.money_mod * card.ability.timesSold)
-			card.cost = newcost
-			local newmult = card.ability.extra.mult + (card.ability.extra.mult_mod * card.ability.timesSold)
-			card.ability.extra.mult = newmult
-			table.remove(G.GAME.sellShopJokersSold, 1)
-		end
+	if context.selling_self then
+		card.ability.times_sold = (card.ability.times_sold or 0) + 1
+		G.GAME.csau_saved_deathcards[#G.GAME.csau_saved_deathcards+1] = {
+			key = card.config.center.key,
+			id = card.ability.id,
+			times_sold = card.ability.times_sold,
+			edition = card.edition and 'e_'..card.edition.type or nil
+		}
 	end
 end
 

--- a/items/tags/plinkett.lua
+++ b/items/tags/plinkett.lua
@@ -1,30 +1,34 @@
 local tagInfo = {
     name = 'Plinkett Tag',
     config = {type = 'new_blind_choice'},
-    alerted = true,
     csau_dependencies = {
         'enableVHSs',
     }
 }
 
-tagInfo.loc_vars = function(self, info_queue, card)
+function tagInfo.loc_vars(self, info_queue, card)
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.gote } }
 end
 
-tagInfo.apply = function(self, tag, context)
+function tagInfo.apply(self, tag, context)
     if context.type == self.config.type then
-        tag:yep('+', G.C.VHS,function()
-            local key = 'p_csau_analog4'
-            local card = Card(G.play.T.x + G.play.T.w/2 - G.CARD_W*1.27/2,
-                    G.play.T.y + G.play.T.h/2-G.CARD_H*1.27/2, G.CARD_W*1.27, G.CARD_H*1.27, G.P_CARDS.empty, G.P_CENTERS[key], {bypass_discovery_center = true, bypass_discovery_ui = true})
-            card.cost = 0
-            card.from_tag = true
-            G.FUNCS.use_card({config = {ref_table = card}})
-            card:start_materialize()
-            G.CONTROLLER.locks[tag.ID] = nil
+        sendDebugMessage('state: '..tostring(G.STATE))
+        local lock = tag.ID
+        G.CONTROLLER.locks[tag.ID] = true
+        tag:yep('+', G.C.VHS, function()
+            local booster = SMODS.create_card { key = 'p_csau_analog4', area = G.play }
+            booster.T.x = G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2
+            booster.T.y = G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2
+            booster.T.w = G.CARD_W * 1.27
+            booster.T.h = G.CARD_H * 1.27
+            booster.cost = 0
+            booster.from_tag = true
+            G.FUNCS.use_card({config = {ref_table = booster}})
+            booster:start_materialize()
+            G.CONTROLLER.locks[lock] = nil
             return true
         end)
-        self.triggered = true
+        tag.triggered = true
         return true
     end
 end

--- a/items/tags/spirit.lua
+++ b/items/tags/spirit.lua
@@ -19,7 +19,7 @@ end
 tagInfo.apply = function(self, tag, context)
     if context.type == self.config.type then
         tag:yep('+', G.C.STAND,function()
-            if (G.GAME.modifiers.csau_unlimited_stands and G.consumeables.config.card_limit > #G.consumeables.cards) or (G.FUNCS.csau_get_num_stands() < G.GAME.modifiers.max_stands) then
+            if G.consumeables.config.card_limit < #G.consumeables.cards and (G.GAME.modifiers.csau_unlimited_stands  or G.FUNCS.csau_get_num_stands() < G.GAME.modifiers.max_stands) then
                 G.FUNCS.csau_new_stand(false)
             end
             return true

--- a/items/tags/spirit.lua
+++ b/items/tags/spirit.lua
@@ -18,12 +18,15 @@ end
 
 tagInfo.apply = function(self, tag, context)
     if context.type == self.config.type then
-        tag:yep('+', G.C.STAND,function()
-            if G.consumeables.config.card_limit < #G.consumeables.cards and (G.GAME.modifiers.csau_unlimited_stands  or G.FUNCS.csau_get_num_stands() < G.GAME.modifiers.max_stands) then
+        if G.consumeables.config.card_limit >= #G.consumeables.cards or (not G.GAME.modifiers.csau_unlimited_stands and G.FUNCS.csau_get_num_stands() >= G.GAME.modifiers.max_stands) then
+            tag:nope()
+        else
+            tag:yep('+', G.C.STAND,function()
                 G.FUNCS.csau_new_stand(false)
-            end
-            return true
-        end)
+                return true
+            end)
+        end
+
         tag.triggered = true
         return true
     end

--- a/items/vhs/nukie.lua
+++ b/items/vhs/nukie.lua
@@ -11,6 +11,7 @@ local consumInfo = {
         extra = {
             runtime = 6,
             uses = 0,
+            chance = 10
         }
     },
     origin = 'rlm'
@@ -22,11 +23,13 @@ function consumInfo.loc_vars(self, info_queue, card)
 	info_queue[#info_queue+1] = {key = "wheel2", set = "Other", vars = {num}}
     info_queue[#info_queue+1] = {key = "vhs_activation", set = "Other"}
     info_queue[#info_queue+1] = {key = "csau_artistcredit", set = "Other", vars = { G.csau_team.wario } }
-    return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
+    local num2, dom = SMODS.get_probability_vars(self, 1, card.ability.extra.chance, 'csau_nukie_negative')
+    return { vars = { num2, dom, card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
 function consumInfo.calculate(self, card, context)
-    if context.using_consumeable and context.consumeable.config.center.key == 'c_wheel_of_fortune' then
+    if context.using_consumeable and context.consumeable.config.center.key == 'c_wheel_of_fortune'
+    and card.ability.activated and G.FUNCS.find_activated_tape('c_csau_nukie') == card then
         card.ability.extra.uses = card.ability.extra.uses+1
         if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
             G.FUNCS.destroy_tape(card)

--- a/items/vhs/sew.lua
+++ b/items/vhs/sew.lua
@@ -37,7 +37,7 @@ function consumInfo.can_use(self, card)
 end
 
 function consumInfo.calculate(self, card, context)
-    if not card.ability.destroyed and context.check_eternal and context.other_card.ability.set == 'Joker'
+    if card.ability.activated and not card.ability.destroyed and context.check_eternal and context.other_card.ability.set == 'Joker'
     and not context.trigger.from_sell and SMODS.find_card('c_csau_sew')[1] == card then
         if context.trigger.config then
             if context.trigger.config.center.key == 'j_madness' then

--- a/items/vhs/shakma.lua
+++ b/items/vhs/shakma.lua
@@ -27,87 +27,22 @@ function consumInfo.loc_vars(self, info_queue, card)
     return { vars = { card.ability.extra.runtime-card.ability.extra.uses } }
 end
 
-local blacklisted_seeds = {
-    '',
-}
-
-local function blacklisted_seed(seed)
-    if starts_with(seed, "soul_") then
-        return true
-    end
-    if starts_with(seed, "pack") then
-        return true
-    end
-    if table.contains(blacklisted_seeds, seed) then
-        return true
-    end
-    return false
-end
-
-local ref_psr = pseudorandom
-function pseudorandom(seed, min, max, no_shakma)
-    no_shakma = no_shakma or false
-    if not no_shakma then
-        local shakma = G.FUNCS.find_activated_tape('c_csau_shakma')
-        if shakma and not shakma.ability.destroyed and not G.GAME.disable_shakma then
-            if not min and not max and not blacklisted_seed(seed) then
-                send("SHAKMA SEED:")
-                send(seed)
-                shakma:juice_up()
-                shakma.ability.extra.uses = shakma.ability.extra.uses+1
-                if to_big(shakma.ability.extra.uses) >= to_big(shakma.ability.extra.runtime) then
-                    G.FUNCS.destroy_tape(shakma)
-                    shakma.ability.destroyed = true
-                end
-                return 0
+function consumInfo.calculate(self, card, context)
+    if card.ability.activated and not card.ability.destroyed and context.fix_probability and G.FUNCS.find_activated_tape('c_csau_shakma') == card then
+        if context.from_roll then
+            card.ability.extra.uses = math.min(card.ability.extra.runtime, card.ability.extra.uses + 1)
+            if to_big(card.ability.extra.uses) >= to_big(card.ability.extra.runtime) then
+                G.FUNCS.destroy_tape(card)
+                card.ability.destroyed = true
             end
         end
+
+        return {
+            message = context.from_roll and 'Guaranteed!' or nil,
+            numerator = context.denominator,
+            denominator = context.denominator,
+        }
     end
-    return ref_psr(seed, min, max)
-end
-
-local ccfs_ref = create_card_for_shop
-function create_card_for_shop(area)
-    G.GAME.disable_shakma = true
-    local ret =  ccfs_ref(area)
-    G.E_MANAGER:add_event(Event({
-        func = function()
-            G.GAME.disable_shakma = false
-            return true
-        end
-    }))
-    return ret
-end
-
-local ref_open = Card.open
-function Card:open()
-    G.GAME.disable_shakma = true
-    local ret =  ref_open(self)
-    G.E_MANAGER:add_event(Event({
-        func = function()
-            G.E_MANAGER:add_event(Event({
-                func = function()
-                    G.GAME.disable_shakma = false
-                    return true
-                end
-            }))
-            return true
-        end
-    }))
-    return ret
-end
-
-local reroll_shopref = G.FUNCS.reroll_shop
-function G.FUNCS.reroll_shop(e)
-    G.GAME.disable_shakma = true
-    local ret = reroll_shopref(e)
-    G.E_MANAGER:add_event(Event({
-        func = function()
-            G.GAME.disable_shakma = false
-            return true
-        end
-    }))
-    return ret
 end
 
 function consumInfo.can_use(self, card)

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -2400,19 +2400,14 @@ return {
 				},
 			},
 			j_csau_protogent = {
-				name = {
-					"Protegent",
-					"Antivirus",
-				},
+				name = "Protegent Antivirus",
 				text = {
 					{
-						"{C:green}#1# in #2#{} chance to",
-						"disable {C:attention}Boss Blinds{}",
+						"{C:green}#1# in #2#{} chance to disable {C:attention}Boss Blinds{}",
 						"{S:1.1,C:red,E:2}self destructs{}",
 					},
 					{
-						"{C:green}#1# in #3#{} chance to",
-						"prevent {C:red,E:1}death{}",
+						"{C:green}#1# in #3#{} chance to prevent {C:red,E:1}death{}",
 						"{S:1.1,C:red,E:2}self destructs{}",
 					}
 				},
@@ -2846,10 +2841,11 @@ return {
 				text = {
 					{
 						"While {C:attention}playing{}, {C:attention}Wheel of Fortune{}",
-						"has a chance to give {C:dark_edition}Negative{}",
+						"has a {C:green}#1# in #2#{} chance to give",
+						"{C:dark_edition}Negative{} when it {C:attention}succeeds{}"
 					},
 					{
-						"{C:vhs}Running Time{}: {C:attention}#1#{} Wheels"
+						"{C:vhs}Running Time{}: {C:attention}#3#{} Wheels"
 					}
 				},
 			},

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -3841,6 +3841,7 @@ return {
 				name = "Spirit Tag",
 				text = {
 					"Create a random {C:stand}Stand",
+					"if not at {C:attention}Stand limit{}",
 					"{C:inactive}(Must have room)",
 				},
 			},

--- a/lovely/jokers.toml
+++ b/lovely/jokers.toml
@@ -30,26 +30,6 @@ overwrite = false
 
 [[patches]]
 [patches.pattern]
-target = "functions/UI_definitions.lua"
-pattern = '''
-        create_shop_card_ui(card)
-        return card
-'''
-position = "after"
-payload = '''
-    elseif G.GAME.spawnSellShopJokers and G.GAME.spawnSellShopJokers ~= 0 then
-        local card_ref = G.GAME.sellShopJokersSold[1]
-		local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, G.P_CARDS.empty, G.P_CENTERS[card_ref.key])
-		create_shop_card_ui(card)
-		G.GAME.forcedeath = false
-		G.GAME.spawnSellShopJokers = G.GAME.spawnSellShopJokers - 1
-		return card
-'''
-match_indent = true
-overwrite = false
-
-[[patches]]
-[patches.pattern]
 target = "functions/common_events.lua"
 pattern = "if add and not G.GAME.banned_keys[v.key] then"
 position = "before"

--- a/lovely/vhs.toml
+++ b/lovely/vhs.toml
@@ -24,13 +24,14 @@ pattern = "edition = poll_edition('wheel_of_fortune', nil, true, true)"
 position = "at"
 payload = '''
 local nukie = G.FUNCS.find_activated_tape('c_csau_nukie')
-local no_neg = true
-if nukie then no_neg = false end
-edition = poll_edition('wheel_of_fortune', nil, no_neg, true)
+if nukie and SMODS.pseudorandom_probability(nukie, 'csau_nukie_negative', 1, nukie.ability.extra.chance) then
+    edition = {negative = true}
+else
+    edition = poll_edition('wheel_of_fortune', nil, true, true)
+end
 if edition == 'e_polychrome' and next(SMODS.find_card('j_csau_speen')) then
     check_for_unlock({ type = "high_speen" })
-end
-'''
+end'''
 match_indent = true
 times = 1
 


### PR DESCRIPTION
- Reworked Deathcard for simpler implementation
  - Deathcard now cannot respawn on rerolls within the same shop
- Added a simple fix for better Bunji compatibility
- Fixed Spirit Tags giving you a Stand if you have full consumable slots (they now simply fail)
- Fixed Nukie's running time ticking down when not activated
- Fixed Surviving Edged Weapons's effect occurring when not activated
- Reworked Shakma with new SMODS probability API
- Reworked Nukie to now have an explicit 1 in 10 chance to grant Negative directly, modifiable by other probability manipulators